### PR TITLE
docs: add SDD revamp planning and editor guide

### DIFF
--- a/docs/editor-guide.md
+++ b/docs/editor-guide.md
@@ -1,0 +1,180 @@
+# SDG AI Lab — Content Editor Guide
+
+This guide is for non-technical staff who manage the SDG AI Lab website content. You can update statistics, projects, news, team members, partners, and page content through the Admin Panel without involving a developer.
+
+---
+
+## Table of Contents
+
+1. [Accessing the Admin Panel](#accessing-the-admin-panel)
+2. [Logging In](#logging-in)
+3. [Dashboard Overview](#dashboard-overview)
+4. [Where Content Appears on the Website](#where-content-appears-on-the-website)
+5. [Managing Content](#managing-content)
+6. [Status: Draft, Published, Archived](#status-draft-published-archived)
+7. [Uploading Images](#uploading-images)
+8. [Tips and Reminders](#tips-and-reminders)
+
+---
+
+## Accessing the Admin Panel
+
+1. Open your web browser and go to the SDG AI Lab website.
+2. In the address bar, add `/admin` at the end of the URL.
+
+   - **Production**: `https://sdgailab.org/admin`
+   - **Staging**: `https://sdg-ai-lab.github.io/sdgailab.github.io/admin`
+
+3. You will see a login screen. You must have an editor account — contact your site administrator if you need access.
+
+---
+
+## Logging In
+
+The admin uses **passwordless login** (no passwords to remember):
+
+1. Enter your work email address.
+2. Click **Send Magic Link**.
+3. Check your email inbox for a message from Supabase. The subject may mention "Magic Link" or "Sign in".
+4. Click the link in the email. Your browser will open the admin dashboard.
+5. You stay logged in until you click **Sign Out** or close the browser (depending on your session settings).
+
+**If you don't receive the email:**
+
+- Check your spam or junk folder.
+- Wait a minute and try again.
+- Ask your administrator to confirm your email is added as an editor.
+
+---
+
+## Dashboard Overview
+
+After logging in, you see the **Dashboard** — a grid of cards, one for each content type:
+
+| Card | What It Manages |
+|------|-----------------|
+| **Statistics** | Impact numbers on the homepage (e.g., "Active Projects: 23") |
+| **Projects** | Project portfolio shown on the Projects page |
+| **News** | News articles on the News page |
+| **People** | Team members and advisors on the Team page |
+| **Partners** | Partner logos on the Partners page and homepage |
+| **Page Content** | Text blocks for the About and Volunteer pages |
+
+Each card shows:
+- The total number of items
+- How many are draft, published, or archived
+- A link — click the card to open that section
+
+Use the **sidebar** on the left to jump between sections anytime.
+
+---
+
+## Where Content Appears on the Website
+
+| Content Type | Where Visitors See It |
+|--------------|------------------------|
+| **Statistics** | Homepage — "Our Impact" section |
+| **Projects** | Homepage (featured projects) + Projects page |
+| **News** | News page |
+| **People** | Team page |
+| **Partners** | Homepage (partner logos) + Partners page |
+| **Page Content** | About page, Volunteer page, Contact page (section blocks) |
+
+Only items with status **Published** appear on the public site. Draft and archived items are visible only in the admin.
+
+---
+
+## Managing Content
+
+### Adding a New Item
+
+1. Click the content type in the sidebar (or on the dashboard).
+2. Click **Add New** (top right of the table).
+3. Fill in the required fields (marked with *).
+4. Set **Status** to **Published** if you want it to show on the website immediately.
+5. Click **Save** or **Create**.
+
+### Editing an Existing Item
+
+1. Go to the content listing.
+2. Find the item and click **Edit**.
+3. Make your changes.
+4. Click **Save** or **Update**.
+
+### Hiding Content Without Deleting (Archive)
+
+1. Go to the content listing.
+2. Find the item and click **Archive**.
+3. The item disappears from the public website but stays in the admin. You can unarchive later by editing and changing status back to **Published**.
+
+### Permanently Deleting Content
+
+You can only permanently delete **archived** items:
+
+1. Find the archived item in the listing.
+2. Click **Delete** (or **Permanently Delete**).
+3. Confirm in the pop-up dialog.
+4. The item is removed from the database and cannot be recovered.
+
+---
+
+## Status: Draft, Published, Archived
+
+| Status | Meaning | Visible on Website? |
+|--------|---------|---------------------|
+| **Draft** | Work in progress | No |
+| **Published** | Live content | Yes |
+| **Archived** | Hidden, not deleted | No |
+
+- Use **Draft** when you are still preparing content.
+- Use **Published** when the content is ready for visitors.
+- Use **Archive** when you want to hide content but keep it for records.
+
+---
+
+## Uploading Images
+
+Projects, news articles, people, and partners can have images (photos, logos, featured images).
+
+**Supported formats:** JPEG, PNG, GIF, WebP, SVG  
+**Maximum size:** 5 MB per file
+
+**To add or replace an image:**
+
+1. In the form, find the image field (e.g., "Image", "Photo", "Logo", "Featured Image").
+2. Click **Upload** or **Choose file**.
+3. Select an image from your computer.
+4. After upload, you will see a preview. Use **Replace** to change it or **Remove** to delete it.
+
+---
+
+## Tips and Reminders
+
+### Unsaved Changes
+
+If you leave a form without saving, the admin will ask: **"You have unsaved changes. Leave anyway?"** Choose **Cancel** to stay and save, or **OK** to discard your changes.
+
+### Session Expired
+
+If you see **"Session expired — please log in again"**, your login has timed out. Enter your email again and click the new magic link to continue.
+
+### Ordering Content
+
+Many content types have a **Display Order** field. Lower numbers appear first. For example, `1` appears before `2`.
+
+### Slug (URL)
+
+For projects and news, a **Slug** is a short URL-friendly version of the title (e.g., "My Project" → "my-project"). It is usually generated automatically. You can edit it if needed.
+
+### Markdown
+
+Project descriptions, news articles, and some page content use **Markdown** — a simple format for bold, lists, links, and headings. The editor shows a preview of how it will look on the site.
+
+### Contact for Help
+
+- **Technical issues** (can't log in, errors, missing features): Contact your site administrator or developer.
+- **Content questions** (what to publish, style, tone): Follow your team's editorial guidelines.
+
+---
+
+*Last updated: 2026*

--- a/docs/sdd/00-index.md
+++ b/docs/sdd/00-index.md
@@ -1,0 +1,34 @@
+# SDG AI Lab Website Revamp -- SDD Document Index
+
+**Spec Driven Development (SDD) documentation for the sdgailab.org revamp.**
+
+| # | Document | Status | Description |
+|---|----------|--------|-------------|
+| 01 | [Client Questionnaire](01-client-questionnaire.md) | Ready to send | 45 questions across 8 categories for gathering client requirements |
+| 02 | [Product Requirements Document](02-product-requirements-document.md) | Draft (v0.1.0) | Goals, audiences, functional/non-functional requirements, constraints, risks |
+| 03 | [Information Architecture](03-information-architecture.md) | Draft (v0.1.0) | Sitemap, navigation design, page hierarchy, URL structure, content types |
+| 04 | [Architecture Decision Record](04-architecture-decision-record.md) | Proposed | 7 ADRs: framework, hosting, CSS, forms, CMS, analytics, icons |
+| 05 | [Wireframes](05-wireframes.md) | Draft (v0.1.0) | Text-based structural wireframes for 6 key pages + global components |
+| 06 | [Project Scaffold](06-project-scaffold.md) | Ready to execute | Astro project setup, directory structure, config files, CI/CD, migration checklist |
+| 07 | [Content Pipeline](07-content-pipeline.md) | Template | Content inventory, delivery tracker, image specs, review checklist |
+| 08 | [Detailed Specification](08-detailed-spec.md) | Draft (v0.1.0) | 17 specs with acceptance criteria, organized into 3 development phases |
+
+## Workflow
+
+```
+[01 Questionnaire] → client answers → [02 PRD v1.0] → [03 IA v1.0]
+                                        ↓
+                                  [04 ADR confirmed]
+                                        ↓
+                         [05 Wireframes] → visual mockups (Figma)
+                                        ↓
+                              [06 Scaffold] → project setup
+                                        ↓
+              [07 Content Pipeline] → content delivered in parallel
+                                        ↓
+                    [08 Spec] → build → review → approve → next spec
+```
+
+## Current Status
+
+All documents are at draft / v0.1.0 status. The next milestone is receiving client responses to the questionnaire (document 01), which will unlock finalizing all other documents to v1.0.0.

--- a/docs/sdd/01-client-questionnaire.md
+++ b/docs/sdd/01-client-questionnaire.md
@@ -1,0 +1,589 @@
+# SDG AI Lab Website Revamp -- Client Requirements Questionnaire
+
+**Prepared by:** SDG AI Lab Development Team
+**Date:** February 2026
+**Purpose:** Collect all critical requirements before beginning the Spec Driven Development (SDD) revamp of [sdgailab.org](https://sdgailab.org).
+
+---
+
+## How to Use This Document
+
+Please answer each question below as completely as possible. Where multiple-choice options are suggested, feel free to pick more than one or write your own answer. A short "why" note accompanies each question to explain what the answer will influence in the build.
+
+Mark your answers inline or return this document with responses filled in.
+
+### Meeting transcript notes (Feb 2026)
+
+- The answers below were partially pre-filled. I updated/augmented them with what was explicitly stated in the provided meeting transcript excerpt.
+- Where the meeting did **not** cover a question (or the excerpt is inconclusive), I marked it as **TBD / not discussed** so we avoid guessing requirements.
+
+---
+
+## 1. Project Goals and Priorities
+
+### 1.1 What is the primary driver for this revamp?
+
+> *Examples: outdated content, modernize the look and feel, rebrand after the 2025 move under UNDP's Digital/AI/Innovation Hub, attract new partners, recruit volunteer data scientists*
+
+**Your answer:** Missing pages, updating website via supabase, or json files, outdated content/information, ease of content update (headless CMS)
+
+*Why this matters:* Establishes the north-star for every design and technical decision. Without a clear "why," scope will drift.
+
+---
+
+### 1.2 Who are the primary audiences for the site?
+
+> *Examples: UNDP internal teams, partner organizations, volunteer data scientists, academic researchers, donors/funders, general public*
+
+**Your answer:** Researcehers, volunteers, UNDP staff, partners, donors, job seekers, general public. Everyone who is interested in the lab's work.
+
+*Why this matters:* Audience determines content depth, tone, navigation hierarchy, and which pages receive the most investment.
+
+---
+
+### 1.3 What are the top 3 actions you want a visitor to take after landing on the site?
+
+> *Examples: contact the lab, explore projects, apply as a volunteer, read research outputs, download datasets*
+
+
+- Information about the lab and its work
+- Explore projects and research outputs
+- Download...
+- Contact the lab
+
+
+*Why this matters:* Drives call-to-action placement, homepage layout, and conversion-oriented design decisions.
+
+---
+
+### 1.4 Are there mandatory UNDP branding guidelines or digital standards we must follow?
+
+> *E.g., color palette, logo usage rules, typography, UNDP web templates or design system*
+
+**Your answer:** keep it at sdgailab level, security standards, ...
+
+*Why this matters:* The current site uses a custom Bootstrap theme. If a UNDP design system exists, we must align with it rather than designing from scratch.
+
+---
+
+### 1.5 Should the site explicitly reflect the new placement under the Digital, AI and Innovation Hub?
+
+> *If so, what specific branding or messaging changes are needed?*
+
+**Your answer:** Yes... 
+
+*Why this matters:* The About Us text already references the 2025 organizational change, but navigation, footer, hero section, and partner logos may also need updates.
+
+---
+
+### 1.6 What does success look like? Are there KPIs?
+
+> *Examples: increased contact form submissions, more volunteer applications, higher web traffic, press coverage, partner inquiries*
+
+**Your answer:** how many visitors, how long they stay, contact, pages loading time, ... (analytics, but pay attention to what is being collected and how it is used)
+
+*Why this matters:* Lets us embed analytics hooks and design for measurable outcomes from day one.
+
+---
+
+## 2. Content and Structure
+
+### 2.1 Should the current 6-page structure be preserved, or are new pages needed?
+
+> *Current pages: Home, About Us, Advisory Board, Projects, Newsroom, Contact Us.*
+> *Possible additions: Publications, Blog, Resources/Tools, Volunteer Portal, Impact/Results*
+
+**Your answer:** Add a dedicated **Volunteer / Volunteering with us** page (move “Volunteer Data Scientist Initiative” content there). Move “Our Approach” content into **About Us**. Consider adding **Blog/News** and **Publications/Resources**. Remove Advisory Board
+
+*Why this matters:* A revamp is the right moment to expand or consolidate the sitemap. The current structure is very lean.
+
+---
+
+### 2.2 The "Active Projects" page lists 5 projects with ~2021 descriptions. Which are still active? Are there new ones? Should completed projects be archived or showcased separately?
+
+Current projects listed:
+
+- Nature, Energy, Climate Cluster (Document classification, NLP for Vertical Fund Portfolio)
+- Connecting Business Initiative (AI R&D for disaster preparedness/response)
+- Business Call to Action (Data visualization, NLP automation)
+- PPMI/OSDG (SDG ontology, training data, ML classifier)
+- Internal Work Streams (Country programme analysis, jobs/skills analysis)
+
+**Still active:**
+
+**New projects to add:**
+
+**Completed / to archive:**
+
+Does not matter if some projects are completed, but we should have a clear way to indicate status. Maybe a "Completed Projects" section or tag?
+
+*Why this matters:* Stale project listings undermine credibility. We need a current, accurate inventory.
+
+---
+
+### 2.3 The Newsroom has only 5 articles (2020-2021), all linking to external IICPSD pages. Should we add newer news? Host articles on-site or keep linking externally?
+
+- Add newer news articles
+- Host articles directly on the site (requires blog/CMS capability)
+- Continue linking to external pages
+- Other: ___
+
+**Your answer:** Add newer news. Hosting strategy is **TBD / not discussed in the provided excerpt** (options: keep external links for legacy items but host new updates on-site via a blog/CMS).
+
+*Why this matters:* Determines whether we need a CMS/blog system or can keep the simple card-and-link approach.
+
+---
+
+### 2.4 Are the 8 Advisory Board members and their titles still current?
+
+Current members listed: Boris Alberda, Hande Bilir, Samira Khan, Soonson Kwon, Prof. Ebru Akcapinar Sezer, Dr. Serdar Turkeli, Natalia Villalobos, Prof. Deniz Yuret
+
+- All current -- no changes needed
+- Some need updating (please specify)
+- Members to remove: ___
+- Members to add: ___
+
+This page will be removed
+
+*Why this matters:* Professional titles change frequently; outdated information reflects poorly on the organization.
+
+---
+
+### 2.5 The About Us page lists generic roles without names or photos. Should we add named team members with bios?
+
+> *Current roles: Technical Advisor, Onsite Data Scientists, Online Data Scientists, Partnership & Outreach Analyst, Data Science Fellow*
+
+- Yes -- add names, photos, and short bios
+- Keep roles only, no personal details
+- Other: ___
+
+Remove the management section here, and add a "Our Team" page with more details about the people behind the lab (Check Jackson work on develop branch. Might have Our team page)
+
+*Why this matters:* Named team members humanize the organization and build trust with potential partners and volunteers.
+
+---
+
+### 2.6 Do you want to showcase publications, research papers, datasets, or open-source tools the lab has produced?
+
+- Yes -- dedicated Publications/Resources page
+- Yes -- link to them from project pages
+- No -- not a priority right now
+- Other: ___
+
+*Why this matters:* The lab's GitHub org has public repositories that could be surfaced. This is a major value-add for academic and technical audiences.
+
+Datasets and publications can be on the same page
+
+---
+
+### 2.7 The homepage shows ~12 partner logos. Is this list current? Any to add or remove?
+
+Current partners/supporters: GEF, The Global Fund, UNDP, Green Climate Fund, Connecting Business Initiative, Business Call to Action, UNOCHA, PPMI, UN Volunteers, IICPSD, and government supporters (China, Kazakhstan, South Korea, Turkey).
+
+**Partners to add:**
+
+**Partners to remove:**
+
+*Why this matters:* Partner logos are a trust signal. In a UN context, displaying outdated logos can cause diplomatic sensitivity issues.
+
+Have a dedicated Partners page (make this dynamic so we can easily update logos and links in the future without code changes)
+
+---
+
+### 2.8 The footer has Twitter and GitHub buttons. Twitter is now "X". Should we update social links? Add others?
+
+- Update Twitter to X
+- Add LinkedIn
+- Add YouTube
+- Remove social links entirely
+- Other: ___
+
+*Why this matters:* Social presence has likely evolved significantly since 2021.
+
+---
+
+### 2.9 Is there a multilingual requirement?
+
+> *Currently English-only. Does the site need Arabic, Turkish, French, or other UN languages?*
+
+- English only
+- Add specific languages: ___
+- Plan for multilingual later (not phase 1)
+
+*Why this matters:* Multilingual support fundamentally impacts architecture choices (i18n framework, content management, URL strategy).
+
+No need for multilingual support at this time, but we should design the architecture to allow adding it later without a major overhaul.
+
+---
+
+## 3. Design and User Experience
+
+### 3.1 Are there reference websites (UN or otherwise) whose design you admire?
+
+> *Please share 2-3 URLs and a brief note on what you like about each.*
+
+**Your answer:** No specific reference sites. Maintain continuity with the current SDG AI Lab look and feel.
+
+
+
+
+
+*Why this matters:* Reference sites accelerate design alignment and dramatically reduce revision cycles.
+
+---
+
+### 3.2 The hero section uses a particles.js animation on a dark blue background. Keep, refresh, or replace?
+
+- Keep as-is
+- Refresh / modernize the animation
+- Replace with a new design (describe vision: ___)
+- No strong preference
+
+*Why this matters:* The particles animation is the site's most distinctive visual element but may feel dated in 2026.
+
+**Your answer:** Keep as-is (retain particles.js hero).
+
+---
+
+### 3.3 Should we do a mobile-first responsive redesign?
+
+- Yes -- mobile-first is a priority
+- Responsive is fine, no need to prioritize mobile
+- Other: ___
+
+*Why this matters:* A UN audience in developing countries is likely heavily mobile. Over 50% of global web traffic is mobile.
+
+**Your answer:** Yes — mobile-first is a priority.
+
+---
+
+### 3.4 Are there specific accessibility standards to meet?
+
+- WCAG 2.1 AA (standard for UN properties)
+- WCAG 2.1 AAA
+- No specific requirement, but best effort
+- Other: ___
+
+*Why this matters:* A full revamp should target a defined standard with testable acceptance criteria.
+
+**Your answer:** WCAG 2.1 AA.
+
+---
+
+### 3.5 Should the design support data-heavy visualizations?
+
+> *E.g., interactive SDG impact maps, project dashboards, embedded charts*
+
+- Yes -- this is important
+- Maybe later, not for initial launch
+- No
+
+*Why this matters:* If yes, we need to plan for charting libraries and a layout strategy that accommodates dynamic content.
+
+**Your answer:** Phase 1 should be light-weight: statistics cards (and optionally a simple world map view). No dashboards in the initial launch.
+
+---
+
+### 3.6 Do you want a dark mode option?
+
+- Yes
+- No
+- Nice to have, not critical
+
+*Why this matters:* Increasingly expected in modern tech-oriented sites. Affects the entire design token system.
+
+No need
+
+---
+
+## 4. Technical and Functional Requirements
+
+### 4.1 Should we migrate to a modern framework/static site generator, or stay with plain HTML?
+
+> *Options: Next.js, Astro, Hugo, 11ty, or remain on plain HTML/Bootstrap*
+
+**Your preference:** Prefer moving to a modern framework/SSG. Meeting note: another branch/version was checked and it used **Gatsby** (“other branch… used Gatsby”). Final choice between Gatsby vs alternatives (Astro/Next/Hugo/11ty) is **TBD**.
+
+*Why this matters:* The current site duplicates navigation and footer code across 6 HTML files. A framework enables reusable components, build optimization, and easier long-term maintenance.
+
+---
+
+### 4.2 Is a CMS needed so non-technical team members can update content?
+
+> *Options: headless CMS (Sanity, Strapi), Markdown-based (Decap CMS), or keep manual editing*
+
+- Yes -- essential
+- Nice to have
+- No -- developers will handle content updates
+
+*Why this matters:* The lab will keep producing news and project updates. Manual HTML editing does not scale.
+
+**Your answer:** Yes — essential (Phase 1). CMS should be Supabase-backed.
+
+---
+
+### 4.3 Should the site remain on GitHub Pages, or move to another host?
+
+- Stay on GitHub Pages
+- Move to Netlify
+- Move to Vercel
+- Move to Azure Static Web Apps
+- UNDP internal hosting
+- No preference
+
+*Why this matters:* Hosting choice affects CI/CD pipeline, form handling, serverless functions, preview deployments, and domain management.
+
+Stay on Github pages
+
+---
+
+### 4.4 The contact form currently uses `mailto:` (opens the user's email client). Should we implement a real form backend?
+
+- Yes -- implement a proper form submission (Formspree, Netlify Forms, EmailJS, or custom)
+- No -- mailto is fine
+- Other: ___
+
+*Why this matters:* The current form does not submit data to a server. It is unreliable and loses submissions silently when users don't have a configured email client.
+
+No need
+
+---
+
+### 4.5 Should we integrate analytics?
+
+- Google Analytics
+- Plausible (privacy-focused)
+- Matomo
+- UNDP's analytics platform
+- No analytics needed
+- Other: ___
+
+*Why this matters:* Currently there is zero visibility into who visits the site or how they use it.
+
+Yes
+
+---
+
+### 4.6 Do you need search functionality on the site?
+
+- Yes
+- Only if we add a blog/publications section
+- No
+
+*Why this matters:* Becomes important if we add publications, a blog, or a large project portfolio.
+
+No need, but can be added later
+
+---
+
+### 4.7 Are there any third-party integrations needed?
+
+> *Examples: GitHub activity feeds, UNDP APIs, newsletter signup (Mailchimp), calendar/events, RSS feeds*
+
+**Your answer:** No
+
+*Why this matters:* Integrations affect architecture and may require API keys or backend support.
+
+---
+
+### 4.8 Are there security or compliance requirements?
+
+> *Examples: Content Security Policy headers, cookie consent (GDPR), data retention policies for form submissions*
+
+**Your answer:** Google Analytics is acceptable. Implement cookie consent if required. Follow UNDP/UN security guidance where applicable, and define privacy notice + data retention rules (especially if storing form submissions or volunteer applications).
+
+*Why this matters:* UN digital properties often have specific security and privacy mandates.
+
+---
+
+## 5. Data, Visualization, and Impact Reporting
+
+### 5.1 Does the lab produce dashboards, interactive tools, or visualizations that should be embedded or linked?
+
+> *E.g., the OSDG classifier, GIS prototypes, Jupyter notebooks*
+
+**Your answer:** **TBD / not discussed in the provided excerpt.** Related meeting idea: show **impact statistics** prominently (potentially with a world map) rather than long descriptive text on the homepage.
+
+*Why this matters:* Showcasing AI work interactively would be a powerful differentiator for the lab's site.
+
+---
+
+### 5.2 Should the site display impact metrics?
+
+> *E.g., "X volunteer hours contributed", "Y countries reached", "Z projects completed"*
+
+- Yes -- prominently on the homepage
+- Yes -- on a dedicated Impact page
+- No
+
+*Why this matters:* Impact numbers are compelling for donors, partners, and volunteer recruitment.
+
+Yes — prominently on the homepage. Meeting direction: replace “in your face” descriptive blocks with **statistics cards** (and potentially a **world map** view showing volunteer reach/metrics). Also: move “Volunteer Data Scientist Initiative” to a dedicated **Volunteer** page, and move “Our Approach” to **About Us**.
+
+---
+
+### 5.3 Should project pages include status indicators, timelines, or progress tracking?
+
+- Yes
+- No -- keep it simple
+- Other: ___
+
+*Why this matters:* Transforms static project cards into something dynamic and informative.
+
+At least a status indicator would be good to have. Meeting categories discussed: **Active**, **Completed**, **Under development**, and possibly **On hold**; also discussed that “deployed / not deployed” is a different dimension and needs a clear mix (e.g., separate badges or fields). Timeline/progress tracking:  **not** in initial scope.
+
+---
+
+## 6. Timeline, Budget, and Deliverables
+
+### 6.1 What is the target launch date?
+
+**Your answer:** No fixed date stated in the provided excerpt. Meeting sentiment: urgency is high (“timeline is yesterday after now”). Proposed approach: define a near-term Phase 1 launch + phased follow-ups. (**TBD**: confirm an actual launch date.)
+
+*Why this matters:* Determines whether we do a phased rollout or a single launch.
+
+---
+
+### 6.2 Is there an event, report release, or organizational milestone the launch should align with?
+
+**Your answer:** **No.**
+
+*Why this matters:* External deadlines are non-negotiable and must be planned around.
+
+---
+
+### 6.3 Should we plan for a phased approach?
+
+> *Example: Phase 1 -- content refresh + new design; Phase 2 -- CMS + blog; Phase 3 -- interactive features/dashboards*
+
+- Yes -- phased is preferred
+- No -- deliver everything at once
+- Open to suggestions
+
+*Why this matters:* Phasing reduces risk and delivers value incrementally, which aligns naturally with SDD.
+
+**Your answer:** No — deliver everything at once (single launch).
+
+---
+
+### 6.4 What is the budget situation?
+
+> *Are paid tools, hosting, or services an option, or must everything be free/open-source?*
+
+- Budget available for paid tools
+- Must be free/open-source only
+- Small budget -- case-by-case
+- Other: ___
+
+*Why this matters:* Affects choices for CMS, hosting, form handling, analytics, and design assets.
+
+**Your answer:** Must be free/open-source only.
+
+---
+
+### 6.5 Who will provide content (text, images, bios, project descriptions)? What is their availability?
+
+**Content owner(s):**
+
+**Availability:**
+
+*Why this matters:* Content is almost always the bottleneck. Identifying the content owner early prevents delays.
+
+---
+
+## 7. Feedback and Review Process
+
+### 7.1 Who are the decision-makers and stakeholders who must approve design and content?
+
+**Your answer:** From the meeting transcript excerpt, participants/stakeholders include **Dina Akylbekova** and **Gokhan Dikmener**. Final decision-maker / approver list is **TBD** (needs confirmation of who signs off on content vs design vs technical decisions).
+
+*Why this matters:* Knowing the approval chain prevents last-minute surprises and scope changes.
+
+---
+
+### 7.2 What is the preferred review cadence?
+
+- Weekly demos / check-ins
+- Milestone-based reviews
+- Async PR reviews on GitHub
+- Other: ___
+
+*Why this matters:* SDD works best with structured feedback loops tied to spec milestones.
+
+**Your answer:** No formal cadence required (ad-hoc check-ins as needed).
+
+---
+
+### 7.3 Should we set up a staging/preview environment for reviews?
+
+- Yes -- essential
+- Nice to have
+- Not needed
+
+*Why this matters:* Lets stakeholders review changes in-browser before anything goes live.
+
+**Your answer:** Not needed.
+
+---
+
+### 7.4 Preferred communication channel for feedback?
+
+- GitHub Issues
+- Email
+- Microsoft Teams
+- Slack
+- Other: ___
+
+*Why this matters:* Centralizing feedback prevents it from being scattered and lost.
+
+**Your answer:** No preference / not required (use ad-hoc communication as needed).
+
+---
+
+### 7.5 Are there past redesign attempts or mockups we should reference?
+
+> *Note: we found `blog-style-newsroom` and `nav-colors` branches in the repository that suggest prior exploration.*
+
+**Your answer:** No. no need to reference past redesign attempts
+
+*Why this matters:* Knowing what was previously tried and why it was abandoned avoids redoing rejected ideas.
+
+---
+
+## 8. Proactive Suggestions
+
+We would like to propose the following enhancements. Please indicate your interest level for each.
+
+
+| #   | Proposal                                                                                                                              | Interest                                       |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| 8.1 | **AI Showcase page** -- live demos or embedded apps (Gradio/Streamlit) demonstrating the lab's work                                   | [ ] High [ ] Medium [ ] Low [ ] Not interested |
+| 8.2 | **Volunteer Portal** -- application flow for data scientists to express interest                                                      | [ ] High [ ] Medium [ ] Low [ ] Not interested |
+| 8.3 | **Interactive Impact Timeline** -- visual history of the lab from 2019 to present                                                     | [ ] High [ ] Medium [ ] Low [ ] Not interested |
+| 8.4 | **SEO overhaul** -- add meta descriptions, Open Graph tags, structured data (currently none exist)                                    | [ ] High [ ] Medium [ ] Low [ ] Not interested |
+| 8.5 | **Newsletter / Subscribe for Updates** feature                                                                                        | [ ] High [ ] Medium [ ] Low [ ] Not interested |
+| 8.6 | **Open Source section** -- link to the lab's GitHub repositories                                                                      | [ ] High [ ] Medium [ ] Low [ ] Not interested |
+| 8.7 | **SDG tagging** -- tag each project with SDG icons (Goals 1-17)                                                                       | [ ] High [ ] Medium [ ] Low [ ] Not interested |
+| 8.8 | **Performance optimization** -- modern build pipeline to reduce load time (current site loads 12+ CSS and 10+ JS files synchronously) | [ ] High [ ] Medium [ ] Low [ ] Not interested |
+
+
+**Any other ideas or features you'd like to see?**
+
+---
+
+## Next Steps
+
+Once this questionnaire is returned, we will:
+
+1. Synthesize answers into a **Product Requirements Document (PRD)**
+2. Create the **Information Architecture** (revised sitemap and page hierarchy)
+3. Finalize the **Tech Stack** with an Architecture Decision Record
+4. Build **low-fidelity wireframes** for client sign-off
+5. Set up the **project scaffold** with CI/CD and preview deploys
+6. Establish a **content pipeline** with assignments and due dates
+7. Write the **detailed SDD spec** with acceptance criteria per page/feature
+8. Begin **iterative development** following the spec-build-review cycle
+
+---
+
+*Thank you for taking the time to answer these questions thoroughly. Your responses will directly shape the specification and ensure the revamp meets your needs.*

--- a/docs/sdd/02-product-requirements-document.md
+++ b/docs/sdd/02-product-requirements-document.md
@@ -1,0 +1,249 @@
+# Product Requirements Document (PRD)
+
+## SDG AI Lab Website Revamp
+
+| Field | Value |
+|-------|-------|
+| **Document version** | 0.1.0 (Draft) |
+| **Date** | February 2026 |
+| **Status** | Awaiting client input |
+| **Owner** | SDG AI Lab Development Team |
+| **Stakeholders** | _TBD -- see Section 7 of client questionnaire_ |
+
+---
+
+## 1. Executive Summary
+
+The SDG AI Lab website ([sdgailab.org](https://sdgailab.org)) is being revamped to address outdated content (last updated mid-2021), modernize the design and technology stack, and better represent the lab's current work and organizational position under UNDP's Digital, AI and Innovation Hub (since 2025).
+
+This PRD captures the baseline state of the site, defines the scope of the revamp, and will be updated with confirmed requirements once client questionnaire responses are received.
+
+---
+
+## 2. Background and Current State
+
+### 2.1 What is SDG AI Lab?
+
+A joint initiative of UNDP's Bureau for Policy and Programme Support (BPPS) and the Sustainable Finance Hub, hosted under UNDP IICPSD in Istanbul, Turkey. Established in 2019. Since 2025, operating under UNDP's Digital, AI and Innovation Hub. The lab provides AI/ML research and advisory support for sustainable development.
+
+### 2.2 Current Site Audit
+
+| Dimension | Current State | Issue |
+|-----------|--------------|-------|
+| **Pages** | 6 static HTML files (Home, About Us, Advisory Board, Projects, Newsroom, Contact Us) | No templating; nav/footer duplicated across all files |
+| **Tech stack** | Bootstrap 5, jQuery, particles.js, AOS, Font Awesome, Simple Line Icons, Typicons | No build system, no package manager, no framework |
+| **Hosting** | GitHub Pages (sdgailab.github.io) with CNAME to sdgailab.org | No CI/CD beyond GitHub Pages auto-deploy |
+| **Content freshness** | Last substantive update: June 2021 (v0.1.1) | 5-year-old project descriptions, newsroom articles from 2020-2021 |
+| **SEO** | No meta descriptions, no Open Graph tags, no structured data, no sitemap.xml, no robots.txt | Invisible to search engines and social sharing |
+| **Analytics** | None | Zero visibility into traffic or user behavior |
+| **Contact form** | `mailto:` action -- opens email client, no server submission | Unreliable; loses submissions silently |
+| **Accessibility** | Recent improvements (PR #60) but no formal standard targeted | No WCAG compliance claim |
+| **Performance** | 12 CSS files, 10+ JS files loaded synchronously; both particles.js AND particles.min.js loaded | Redundant loads, no bundling, no minification pipeline |
+| **Social links** | Twitter follow button (still says "Twitter", not "X"), GitHub follow button | Outdated branding |
+| **Mobile** | Responsive via Bootstrap grid, but not mobile-first designed | Functional but not optimized |
+
+### 2.3 Codebase Structure
+
+```
+sdgailab.github.io/
+  index.html              # Homepage with particles.js hero
+  about-us.html           # Lab description and team structure (roles only, no names)
+  advisory-board.html     # 8 board members with photos
+  active-projects.html    # 5 project cards (content from ~2021)
+  newsroom.html           # 5 external article links (2020-2021)
+  contact-us.html         # mailto: form
+  CNAME                   # sdgailab.org
+  README.md               # Version history (v0.1.0, v0.1.1)
+  assets/
+    bootstrap/            # Bootstrap CSS + JS (local)
+    css/                  # 8 CSS files (style.css + component-specific)
+    js/                   # 10 JS files (jQuery, particles, AOS, theme, etc.)
+    fonts/                # Font Awesome, Simple Line Icons, Typicons
+    img/                  # Logo, hero image, partner logos, board photos, news images
+  icons/                  # Favicons, webmanifest, browserconfig
+```
+
+### 2.4 Git Branch Landscape
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Production (current live site) |
+| `new-version` | **Active revamp branch** (current work) |
+| `develop` | Development integration |
+| `blog-style-newsroom` | Prior exploration: blog-style newsroom layout |
+| `nav-colors` | Prior exploration: navigation color scheme |
+| `harmonize-fonts` | Merged: font standardization to Open Sans |
+| `improve-accessibility-and-code-quality` | Merged: accessibility + code quality fixes |
+| `fix/html-validation-errors` | Merged: HTML validation |
+| `feat/dynamic-copyright-year` | Merged: dynamic copyright year |
+| `fix-ids-duplicates` | Merged: duplicate ID removal |
+
+---
+
+## 3. Goals
+
+> _To be confirmed by client. Draft goals based on site audit:_
+
+| # | Goal | Priority | Status |
+|---|------|----------|--------|
+| G1 | Update all content to reflect current (2026) state of the lab | **Must have** | _Awaiting confirmation_ |
+| G2 | Modernize visual design and UX | **Must have** | _Awaiting confirmation_ |
+| G3 | Migrate to a component-based framework with build pipeline | **Should have** | _Awaiting confirmation_ |
+| G4 | Add SEO metadata (descriptions, OG tags, structured data) | **Should have** | _Awaiting confirmation_ |
+| G5 | Implement a working contact form with server-side submission | **Should have** | _Awaiting confirmation_ |
+| G6 | Add analytics tracking | **Should have** | _Awaiting confirmation_ |
+| G7 | Integrate CMS for non-technical content updates | **Could have** | _Awaiting confirmation_ |
+| G8 | Add interactive features (AI showcase, impact dashboard) | **Could have** | _Awaiting confirmation_ |
+
+---
+
+## 4. Target Audience
+
+> _To be confirmed by client. Preliminary audience mapping:_
+
+| Audience | Needs | Priority |
+|----------|-------|----------|
+| **Partner organizations** (UN agencies, GEF, Global Fund, etc.) | Understand the lab's capabilities, see active projects, find contact info | _TBD_ |
+| **Volunteer data scientists** | Learn about volunteer opportunities, understand the engagement model, apply | _TBD_ |
+| **UNDP internal teams** | Discover how the lab can support their projects, request collaboration | _TBD_ |
+| **Academic researchers** | Access publications, datasets, open-source tools | _TBD_ |
+| **Donors / funders** | See impact metrics, understand the lab's value proposition | _TBD_ |
+| **General public** | Learn what SDG AI Lab does, browse news | _TBD_ |
+
+---
+
+## 5. Functional Requirements
+
+### 5.1 Must Have (Baseline)
+
+| ID | Requirement | Notes |
+|----|-------------|-------|
+| FR-01 | All pages render correctly on desktop, tablet, and mobile | Mobile-first responsive design |
+| FR-02 | Navigation works across all pages with consistent structure | Currently duplicated HTML; should use shared component |
+| FR-03 | Homepage communicates the lab's mission and key offerings | Current hero + approach sections as baseline |
+| FR-04 | Projects page displays current project portfolio | Content update required from client |
+| FR-05 | About Us page describes the lab, its organizational placement, and team | Content update required from client |
+| FR-06 | Contact form submits data reliably to a backend | Replace current mailto: with real form handler |
+| FR-07 | Footer contains current social media links and copyright | Update Twitter to X; confirm other channels |
+
+### 5.2 Should Have
+
+| ID | Requirement | Notes |
+|----|-------------|-------|
+| FR-08 | SEO metadata on all pages (title, description, OG tags, canonical URLs) | Currently absent entirely |
+| FR-09 | Analytics integration | Platform TBD by client |
+| FR-10 | Performance-optimized build (bundled CSS/JS, minification, image optimization) | Current: 22+ unoptimized asset loads |
+| FR-11 | Accessibility compliance (WCAG 2.1 AA target) | Level TBD by client |
+| FR-12 | Newsroom with current articles | On-site hosting vs. external links TBD |
+| FR-13 | Advisory Board page with verified, current member information | Content update required from client |
+| FR-14 | Updated partner/supporter logos | Verification required from client |
+
+### 5.3 Could Have
+
+| ID | Requirement | Notes |
+|----|-------------|-------|
+| FR-15 | CMS for non-technical content updates | Tool and approach TBD |
+| FR-16 | Blog / on-site article hosting | Depends on newsroom strategy |
+| FR-17 | Publications / Resources page | Depends on client interest |
+| FR-18 | Volunteer application portal | Depends on client interest |
+| FR-19 | AI Showcase page with embedded demos | Depends on client interest |
+| FR-20 | Impact metrics / dashboard | Depends on client interest |
+| FR-21 | SDG icon tagging on projects | Depends on client interest |
+| FR-22 | Newsletter subscription | Depends on client interest |
+| FR-23 | Search functionality | Depends on content volume |
+| FR-24 | Dark mode | Depends on client interest |
+| FR-25 | Multilingual support | Depends on client requirement |
+
+---
+
+## 6. Non-Functional Requirements
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-01 | Page load time (Largest Contentful Paint) | < 2.5 seconds on 3G |
+| NFR-02 | Lighthouse Performance score | >= 90 |
+| NFR-03 | Lighthouse Accessibility score | >= 90 |
+| NFR-04 | Lighthouse SEO score | >= 90 |
+| NFR-05 | Browser support | Last 2 versions of Chrome, Firefox, Safari, Edge |
+| NFR-06 | Uptime | 99.9% (GitHub Pages SLA) |
+| NFR-07 | Deployment | Automated via CI/CD on push to main branch |
+| NFR-08 | Code maintainability | Component-based architecture, linted, formatted |
+
+---
+
+## 7. Constraints
+
+| Constraint | Details |
+|------------|---------|
+| **Domain** | Must retain sdgailab.org (CNAME currently configured) |
+| **Branding** | Must comply with UNDP guidelines (if applicable -- awaiting confirmation) |
+| **Budget** | _TBD -- awaiting client input_ |
+| **Hosting** | _TBD -- GitHub Pages is default; alternatives under consideration_ |
+| **Content ownership** | Content must be provided/approved by SDG AI Lab team |
+
+---
+
+## 8. Success Metrics
+
+> _To be confirmed by client. Proposed metrics:_
+
+| Metric | Baseline (Current) | Target |
+|--------|-------------------|--------|
+| Lighthouse Performance | _Not measured_ | >= 90 |
+| Lighthouse Accessibility | _Not measured_ | >= 90 |
+| Lighthouse SEO | _Not measured_ | >= 90 |
+| Contact form submissions / month | 0 (form is broken) | _TBD_ |
+| Monthly unique visitors | Unknown (no analytics) | _TBD_ |
+| Average session duration | Unknown | _TBD_ |
+| Volunteer inquiries / month | Unknown | _TBD_ |
+
+---
+
+## 9. Risks and Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Content not delivered on time by client | Delays launch | High | Establish content pipeline with deadlines early; use placeholder content for development |
+| Scope creep from "could have" features | Delays launch, increases cost | Medium | Strict phased approach; lock scope per phase |
+| UNDP branding constraints discovered late | Rework of design | Medium | Ask about branding in questionnaire (Q1.4); research UNDP design standards proactively |
+| Partner logo / advisory board political sensitivity | Diplomatic issues | Low | Require explicit client sign-off on every logo and name |
+| Chosen tech stack unfamiliar to maintainers | Long-term maintenance burden | Medium | Choose framework with good documentation and wide adoption; document everything |
+
+---
+
+## 10. Open Questions
+
+These map directly to the client questionnaire and will be resolved upon receiving responses:
+
+1. Primary driver and KPIs for the revamp (Q1.1, Q1.6)
+2. Target audience prioritization (Q1.2)
+3. Sitemap expansion or consolidation (Q2.1)
+4. Project, advisory board, and partner content updates (Q2.2, Q2.4, Q2.7)
+5. Newsroom strategy: on-site vs. external (Q2.3)
+6. Team member visibility: named bios vs. role-only (Q2.5)
+7. Framework / SSG selection (Q4.1)
+8. CMS requirement (Q4.2)
+9. Hosting platform (Q4.3)
+10. Analytics platform (Q4.5)
+11. Budget constraints (Q6.4)
+12. Timeline and phasing (Q6.1, Q6.3)
+13. Approval chain and review cadence (Q7.1, Q7.2)
+
+---
+
+## Appendix A: Content Inventory
+
+| Page | Content Items | Last Updated | Action Needed |
+|------|--------------|--------------|---------------|
+| **Home** | Hero tagline, "Our Approach" (5 points), "Volunteer Data Scientist Initiative" (4 boxes), Partner logos (12+) | ~2021 | Verify all text; update partner logos |
+| **About Us** | Lab description paragraph, Team structure (5 generic roles, no names/photos) | ~2021 (text updated to mention 2025 change) | Verify text; decide on named team members |
+| **Advisory Board** | 8 member cards with photos, names, titles | ~2021 | Verify all members are current |
+| **Active Projects** | 5 project cards with descriptions | ~2021 | Major update needed; identify active vs. completed |
+| **Newsroom** | 5 article cards linking to external IICPSD pages | 2020-2021 | Add recent news; decide hosting strategy |
+| **Contact Us** | Form (name, email, comments) with mailto: action | ~2021 | Replace with working form backend |
+| **Footer** (all pages) | Twitter button, GitHub button, copyright | ~2021 | Update Twitter to X; add other channels |
+| **Navigation** (all pages) | 6-item nav: Home, About Us, Advisory board, projects, Newsroom, Contact Us | ~2021 | Fix capitalization inconsistency ("projects" lowercase) |
+
+---
+
+_This document will be updated to version 1.0.0 once client questionnaire responses are incorporated._

--- a/docs/sdd/03-information-architecture.md
+++ b/docs/sdd/03-information-architecture.md
@@ -1,0 +1,301 @@
+# Information Architecture (IA)
+
+## SDG AI Lab Website Revamp
+
+| Field | Value |
+|-------|-------|
+| **Document version** | 0.1.0 (Draft) |
+| **Date** | February 2026 |
+| **Status** | Draft -- pending client input on sitemap expansion |
+
+---
+
+## 1. Current Sitemap
+
+The existing site has a flat 6-page structure with no hierarchy:
+
+```
+Home (index.html)
+├── About Us (about-us.html)
+├── Advisory Board (advisory-board.html)
+├── Projects (active-projects.html)
+├── Newsroom (newsroom.html)
+└── Contact Us (contact-us.html)
+```
+
+**Issues with current IA:**
+- Flat structure with no sub-pages or content depth
+- "Projects" nav label says "projects" (lowercase) while page title says "Active Projects"
+- No pathway for volunteers despite being central to the lab's model
+- No publications, resources, or open-source repository visibility
+- Newsroom is a dead-end with 5 stale external links
+- No search, no filtering, no content discovery beyond the main nav
+
+---
+
+## 2. Proposed Sitemap (Expanded)
+
+This proposed sitemap adds depth where the current site is thin. Each section is marked with its dependency on client confirmation.
+
+```
+Home
+│
+├── About
+│   ├── Overview (lab mission, history, organizational placement)
+│   ├── Team (named members with bios and photos)
+│   └── Advisory Board (current member profiles)
+│
+├── Projects
+│   ├── Active Projects (current project cards with SDG tags)
+│   ├── Completed Projects (archived work with outcomes)
+│   └── [Individual Project Pages] (optional deep-dive per project)
+│
+├── Resources [NEW]
+│   ├── Publications (papers, reports, presentations)
+│   ├── Open Source (links to GitHub repositories)
+│   └── Datasets (if applicable)
+│
+├── News
+│   ├── Article List (paginated, with categories)
+│   └── [Individual Article Pages] (if hosting on-site)
+│
+├── Get Involved [NEW]
+│   ├── Volunteer (data scientist application flow)
+│   └── Partner With Us (partnership inquiry)
+│
+└── Contact
+```
+
+### Dependency Matrix
+
+| Proposed Section | Depends On | Client Question |
+|-----------------|------------|-----------------|
+| Team (named members) | Client provides names, bios, photos | Q2.5 |
+| Completed Projects | Client identifies which are completed | Q2.2 |
+| Individual Project Pages | Client confirms depth is wanted | Q2.2 |
+| Resources section | Client confirms interest | Q2.6 |
+| On-site article hosting | Client newsroom strategy decision | Q2.3 |
+| Volunteer portal | Client confirms interest | Q8.2 |
+| Partner With Us | Client confirms interest | Q8.2 |
+
+---
+
+## 3. Navigation Design
+
+### Primary Navigation (Desktop)
+
+```
+[Logo] SDG AI Lab     About ▾    Projects ▾    Resources    News    Get Involved ▾    Contact
+                      ├ Overview  ├ Active                          ├ Volunteer
+                      ├ Team      └ Completed                      └ Partner
+                      └ Board
+```
+
+### Primary Navigation (Mobile)
+
+Hamburger menu with expandable sections. Same hierarchy as desktop, but vertically stacked with accordion-style sub-items.
+
+### Footer Navigation
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  SDG AI Lab                                                     │
+│                                                                 │
+│  About          Projects       Resources      Connect           │
+│  · Overview     · Active       · Publications  · Contact Us     │
+│  · Team         · Completed    · Open Source    · Volunteer      │
+│  · Board                       · Datasets       · Newsletter    │
+│                                                                 │
+│  [X] [GitHub] [LinkedIn]                                        │
+│                                                                 │
+│  © 2026 SDG AI Lab | UNDP Digital, AI and Innovation Hub        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 4. Page Hierarchy and Content Map
+
+### 4.1 Home
+
+| Section | Content | Priority |
+|---------|---------|----------|
+| Hero | Tagline, CTA button(s), background visual | Must have |
+| Mission / Approach | Brief lab description with key methodology points | Must have |
+| Impact Numbers | Key metrics (projects, volunteers, countries) | Should have |
+| Featured Projects | 2-3 highlighted project cards | Should have |
+| Partners | Logo grid of current supporters | Must have |
+| CTA Banner | "Get Involved" or "Contact Us" call-to-action | Should have |
+
+### 4.2 About > Overview
+
+| Section | Content | Priority |
+|---------|---------|----------|
+| Lab Description | Mission, history (est. 2019), organizational placement | Must have |
+| Timeline | Key milestones from 2019 to present | Could have |
+| Methodology | Approach to AI research for SDGs | Must have |
+
+### 4.3 About > Team
+
+| Section | Content | Priority |
+|---------|---------|----------|
+| Team Grid | Named members with photo, title, short bio | Must have (if client approves named members) |
+| Organizational Chart | Visual hierarchy of roles and streams | Could have |
+
+### 4.4 About > Advisory Board
+
+| Section | Content | Priority |
+|---------|---------|----------|
+| Board Members | Photo, name, title, affiliation, short bio | Must have |
+
+### 4.5 Projects > Active
+
+| Section | Content | Priority |
+|---------|---------|----------|
+| Project Cards | Title, description, SDG tags, status indicator | Must have |
+| Filter/Search | Filter by SDG goal, status, or topic | Could have |
+
+### 4.6 Projects > Completed
+
+| Section | Content | Priority |
+|---------|---------|----------|
+| Archived Cards | Title, description, outcomes, date range | Should have |
+
+### 4.7 Resources
+
+| Section | Content | Priority |
+|---------|---------|----------|
+| Publications List | Title, authors, date, abstract, download/link | Could have |
+| GitHub Repos | Repository cards pulled from GitHub API or manually listed | Could have |
+| Datasets | Name, description, download/link | Could have |
+
+### 4.8 News
+
+| Section | Content | Priority |
+|---------|---------|----------|
+| Article List | Title, date, excerpt, image, category tag | Must have |
+| Article Page | Full article content (if hosted on-site) | Depends on Q2.3 |
+
+### 4.9 Get Involved > Volunteer
+
+| Section | Content | Priority |
+|---------|---------|----------|
+| Program Description | What the volunteer program is, expectations, benefits | Could have |
+| Application Form | Name, skills, availability, motivation | Could have |
+
+### 4.10 Contact
+
+| Section | Content | Priority |
+|---------|---------|----------|
+| Contact Form | Name, email, subject, message -- with real backend | Must have |
+| Email / Address | Direct contact info | Should have |
+| Map | Istanbul office location (optional) | Could have |
+
+---
+
+## 5. URL Structure
+
+Proposed clean URL scheme (assuming a framework with routing):
+
+| Page | URL |
+|------|-----|
+| Home | `/` |
+| About Overview | `/about` |
+| Team | `/about/team` |
+| Advisory Board | `/about/advisory-board` |
+| Active Projects | `/projects` |
+| Completed Projects | `/projects/completed` |
+| Individual Project | `/projects/[slug]` |
+| Resources | `/resources` |
+| Publications | `/resources/publications` |
+| Open Source | `/resources/open-source` |
+| News List | `/news` |
+| Individual Article | `/news/[slug]` |
+| Volunteer | `/get-involved/volunteer` |
+| Partner | `/get-involved/partner` |
+| Contact | `/contact` |
+
+If remaining on static HTML (no framework), URLs will be file-path based:
+
+| Page | URL |
+|------|-----|
+| Home | `/index.html` |
+| About | `/about.html` |
+| Team | `/team.html` |
+| Advisory Board | `/advisory-board.html` |
+| Projects | `/projects.html` |
+| etc. | etc. |
+
+---
+
+## 6. Content Types
+
+| Content Type | Fields | Source |
+|-------------|--------|--------|
+| **Page** | title, slug, body content, meta description, OG image | Manual / CMS |
+| **Project** | title, slug, description, SDG tags[], status, date range, outcomes | Manual / CMS |
+| **Team Member** | name, title, photo, bio, stream (Technical/Operational/Professional) | Manual / CMS |
+| **Board Member** | name, title, affiliation, photo, bio | Manual / CMS |
+| **News Article** | title, slug, date, author, excerpt, body, image, category, external URL (if linking out) | Manual / CMS |
+| **Partner** | name, logo image, website URL, category (partner/supporter/government) | Manual / CMS |
+| **Publication** | title, authors, date, abstract, PDF/link, tags | Manual / CMS |
+
+---
+
+## 7. User Flows
+
+### 7.1 Primary: "Learn about the lab"
+
+```
+Home → About Overview → Team → Advisory Board
+```
+
+### 7.2 Primary: "Explore projects"
+
+```
+Home → Projects (Active) → Individual Project → Related Resources
+```
+
+### 7.3 Primary: "Volunteer as a data scientist"
+
+```
+Home → Get Involved → Volunteer → Submit Application
+```
+
+### 7.4 Primary: "Contact the lab"
+
+```
+Any page → Contact (via nav or CTA) → Submit Form → Confirmation
+```
+
+### 7.5 Secondary: "Read latest news"
+
+```
+Home → News → Individual Article
+```
+
+### 7.6 Secondary: "Find publications / open-source tools"
+
+```
+Home → Resources → Publications / Open Source → Download/Link
+```
+
+---
+
+## 8. Fallback: Minimal IA (if client prefers lean site)
+
+If the client does not want an expanded sitemap, the minimal viable IA is:
+
+```
+Home
+├── About (combines overview + team + board)
+├── Projects (active only, no archive)
+├── News (card links to external articles)
+└── Contact (working form)
+```
+
+This keeps the current 6-page spirit but fixes critical issues (broken form, stale content, missing SEO).
+
+---
+
+_This IA will be finalized to version 1.0.0 once the client confirms the sitemap and section priorities._

--- a/docs/sdd/04-architecture-decision-record.md
+++ b/docs/sdd/04-architecture-decision-record.md
@@ -1,0 +1,221 @@
+# Architecture Decision Record (ADR)
+
+## SDG AI Lab Website Revamp -- Tech Stack
+
+| Field | Value |
+|-------|-------|
+| **Document version** | 0.1.0 (Draft) |
+| **Date** | February 2026 |
+| **Status** | Partially confirmed (Feb 2026 meeting + follow-up decisions) |
+| **Decision maker** | _TBD_ |
+
+---
+
+## ADR-001: Framework / Static Site Generator
+
+### Context
+
+The current site is 6 hand-coded HTML files with Bootstrap. Navigation and footer are copy-pasted across every page. There is no build system, no component reuse, and no templating. Adding a new page requires duplicating boilerplate into a new file. The revamp needs a solution that enables component reuse, SEO, performance optimization, and maintainability.
+
+### Options Evaluated
+
+| Option | Pros | Cons | Best For |
+|--------|------|------|----------|
+| **Astro** | Component-based, zero JS by default, excellent performance, Markdown content support, partial hydration, growing ecosystem | Newer ecosystem (though mature by 2026), smaller community than Next.js | Content-heavy static sites with optional interactivity |
+| **Next.js** | Largest React ecosystem, SSG + SSR + ISR, excellent DX, huge community | Heavier than needed for a mostly-static site, React dependency, Vercel-optimized | Dynamic apps, sites needing server-side rendering |
+| **Hugo** | Extremely fast builds, Go templating, no JS dependency, mature | Go templates have a learning curve, less flexible for interactive features | Pure static sites with high build speed |
+| **11ty (Eleventy)** | Flexible templating (Nunjucks, Liquid, etc.), minimal opinions, fast builds, no framework lock-in | Less structured than Astro/Next, smaller ecosystem for components | Developers who want maximum flexibility |
+| **Plain HTML + Build Tools** | No framework to learn, full control | No component reuse, no templating, same maintenance problems as current site | Very small sites that won't grow |
+
+### Recommendation
+
+**Astro** is the recommended choice for this project because:
+
+1. **Content-first:** The SDG AI Lab site is primarily content (text, images, project descriptions). Astro's content collections and Markdown support map perfectly to this.
+2. **Performance:** Astro ships zero JavaScript by default. For a site serving UNDP audiences in bandwidth-constrained regions, this is critical. Interactive elements (forms, animations) use partial hydration ("islands").
+3. **Component reuse:** Astro components solve the current duplication problem (nav/footer across 6 files).
+4. **Flexibility:** Astro can use React, Vue, or Svelte components for interactive parts, without committing the whole site to a framework.
+5. **Static output:** Generates pure static HTML, deployable on GitHub Pages, Netlify, or Vercel without server requirements.
+6. **Markdown/MDX content:** News articles, project descriptions, and team bios can be authored in Markdown, enabling a lightweight CMS-like workflow.
+
+### Decision
+
+> _Pending client confirmation (Q4.1). Astro is the recommended default._
+
+---
+
+## ADR-002: Hosting Platform
+
+### Context
+
+The site is currently hosted on GitHub Pages with a CNAME pointing sdgailab.org to sdgailab.github.io. GitHub Pages is free, reliable, and tightly integrated with the repository. However, it has limitations: no server-side functions, no form handling, no deploy previews for PRs, and limited build customization.
+
+### Options Evaluated
+
+| Option | Cost | Form Handling | Deploy Previews | CI/CD | Serverless Functions |
+|--------|------|--------------|-----------------|-------|---------------------|
+| **GitHub Pages** | Free | None (need external service) | None (manual branch previews only) | GitHub Actions | None |
+| **Netlify** | Free tier generous | Netlify Forms (built-in, free tier) | Automatic per PR | Built-in | Netlify Functions |
+| **Vercel** | Free tier generous | None (need external) | Automatic per PR | Built-in | Edge/Serverless Functions |
+| **Cloudflare Pages** | Free tier generous | None (need external) | Automatic per PR | Built-in | Workers |
+
+### Recommendation
+
+**GitHub Pages** is the recommended choice for this revamp because it is already in use, aligns with the free-only constraint, and avoids introducing new hosting dependencies.
+
+### Decision
+
+> **Accepted:** Stay on GitHub Pages.
+
+---
+
+## ADR-003: CSS / Design System
+
+### Context
+
+The current site uses Bootstrap 5 with 8 additional CSS files (Article-List.css, Team-Clean.css, etc.) and 3 icon font libraries (Font Awesome, Simple Line Icons, Typicons). This results in 12 CSS file loads with significant unused CSS.
+
+### Options Evaluated
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Tailwind CSS** | Utility-first, minimal CSS output (purge unused), consistent design tokens, excellent Astro integration | Learning curve for those used to semantic CSS |
+| **Bootstrap 5 (keep)** | Familiar, large component library, team already knows it | Heavy (unused CSS), opinionated design that looks "Bootstrap-y" |
+| **Vanilla CSS with custom properties** | Full control, no dependencies | More work to build from scratch, no pre-built components |
+| **Open Props** | Modern CSS variables library, lightweight | Smaller community, less documentation |
+
+### Recommendation
+
+**Tailwind CSS** is the recommended choice because:
+
+1. **Performance:** With PurgeCSS (built into Tailwind), the final CSS bundle contains only the classes actually used. This dramatically reduces CSS size compared to the current 12-file setup.
+2. **Design tokens:** Tailwind's configuration file becomes the single source of truth for colors, spacing, typography -- enabling consistent design and easy theme changes.
+3. **Astro integration:** Tailwind has first-class Astro support via `@astrojs/tailwind`.
+4. **Responsive design:** Tailwind's responsive utilities make mobile-first design natural.
+5. **Dark mode:** Built-in dark mode support via the `dark:` variant, if the client wants it (Q3.6).
+
+### Decision
+
+> _Pending client confirmation. Tailwind CSS is the recommended default._
+
+---
+
+## ADR-004: Contact Form Backend
+
+### Context
+
+The current contact form uses `action="MAILTO:sdgailab@undp.org"` with `method="post"` and `enctype="text/plain"`. This opens the user's default email client rather than submitting to a server. If the user has no email client configured (common on mobile), the form silently fails.
+
+### Options Evaluated
+
+| Option | Cost | Setup Complexity | Spam Protection | Data Storage |
+|--------|------|-----------------|-----------------|--------------|
+| **Netlify Forms** | Free (100 submissions/mo) | Zero (add attribute to form HTML) | Built-in honeypot + reCAPTCHA | Netlify dashboard |
+| **Formspree** | Free (50 submissions/mo) | Low (point form action to Formspree URL) | Built-in | Formspree dashboard |
+| **EmailJS** | Free (200 emails/mo) | Low (JS SDK) | reCAPTCHA integration | Email only (no dashboard) |
+| **Custom API** | Hosting cost | High | Must implement | Custom |
+
+### Recommendation
+
+- Keep `mailto:` only if the lab explicitly prefers email-client submission and accepts reliability limitations.
+- If a working backend submission is required later while staying on GitHub Pages (free-only), prefer **Formspree** (free tier) or store submissions in **Supabase** (if the Supabase-backed CMS is already in place).
+
+### Decision
+
+> **Accepted for now:** No dedicated form backend (retain mailto).
+
+---
+
+## ADR-005: Content Management
+
+### Context
+
+The site's content (projects, news, team bios, partner logos) needs regular updates. Currently, all content is hard-coded in HTML. The client questionnaire (Q4.2) asks whether a CMS is needed.
+
+### Options Evaluated
+
+| Option | Cost | Technical Barrier for Editors | Setup Complexity | Content Storage |
+|--------|------|------------------------------|-----------------|-----------------|
+| **Markdown files in repo** | Free | Medium (needs Git knowledge or a Git-based editor) | Low | Git repository |
+| **Decap CMS (formerly Netlify CMS)** | Free | Low (web-based WYSIWYG editor backed by Git) | Medium | Git repository (Markdown files) |
+| **Supabase-backed CMS** | Free tier available | Low-Medium (web UI via Supabase Studio or custom admin) | Medium | Supabase Postgres |
+| **Sanity** | Free tier (3 users) | Low (web-based studio) | Medium-High | Sanity cloud |
+| **No CMS (manual HTML editing)** | Free | High (requires HTML knowledge) | None | Git repository |
+
+### Recommendation
+
+Use a **Supabase-backed CMS** as the system of record for content that changes frequently (news, projects, partners, team).
+
+Because the team needs **immediate updates without redeploys**, the website should use **runtime client-side reads** from Supabase for CMS-driven content. To keep this safe:
+
+- Treat the Supabase **anon** key as public (it will ship to the browser).
+- Enforce access via **Row Level Security (RLS)** and allow public reads only for `published=true` rows.
+- Prefer a `status`/`published_at` field and only expose rows that are published.
+
+If SEO becomes critical for some pages later, consider a hybrid approach (static shells + runtime content, or add an auto-redeploy webhook).
+
+### Decision
+
+> **Accepted:** CMS is essential in Phase 1 and should be Supabase-backed.
+
+---
+
+## ADR-006: Analytics
+
+### Context
+
+The site currently has zero analytics. There is no visibility into traffic, user behavior, or conversion.
+
+### Options Evaluated
+
+| Option | Cost | Privacy | Setup | GDPR Cookie Consent Required |
+|--------|------|---------|-------|------------------------------|
+| **Plausible** | $9/mo (or self-hosted free) | Privacy-focused, no cookies | Script tag | No |
+| **Google Analytics 4** | Free | Collects PII, uses cookies | Script tag + consent banner | Yes |
+| **Matomo** | Free (self-hosted) or paid (cloud) | Configurable privacy | Script tag | Depends on config |
+| **None** | Free | N/A | N/A | N/A |
+
+### Recommendation
+
+Use **Google Analytics 4** (acceptable per client decision). If cookies are used, implement a **cookie consent** mechanism and publish a **privacy notice** describing what is collected and why.
+
+### Decision
+
+> **Accepted:** Google Analytics is acceptable (with cookie consent if required).
+
+---
+
+## ADR-007: Icon System
+
+### Context
+
+The current site loads 3 separate icon font libraries (Font Awesome 4.7, Simple Line Icons, Typicons) but uses only a handful of icons from each. Icon fonts are an older pattern that loads entire character sets for a few glyphs.
+
+### Recommendation
+
+Replace all icon fonts with **inline SVG icons** or a tree-shakeable icon library like **Lucide** or **Heroicons**. This eliminates 3 font file downloads and ensures only used icons are included in the bundle.
+
+### Decision
+
+> _This is a non-controversial optimization. Implement during scaffold setup._
+
+---
+
+## Summary of Recommended Stack
+
+| Layer | Choice | Status |
+|-------|--------|--------|
+| **Framework** | Astro | Proposed |
+| **Styling** | Tailwind CSS | Proposed |
+| **Hosting** | GitHub Pages | Accepted |
+| **Form handling** | mailto (Phase 1), optional Formspree/Supabase later | Accepted (Phase 1) |
+| **Content system of record** | Supabase (Postgres) | Accepted |
+| **CMS** | Supabase-backed (via Supabase Studio or custom admin) | Accepted |
+| **Analytics** | Google Analytics 4 | Accepted |
+| **Icons** | Lucide (inline SVG) | Proposed |
+| **Fonts** | Open Sans via `@fontsource` (self-hosted) | Proposed |
+| **CI/CD** | GitHub Actions (build + deploy to GitHub Pages) | Proposed |
+
+---
+
+Remaining decisions to finalize: framework choice (Gatsby vs alternatives), CSS approach (keep Bootstrap vs Tailwind), and whether the contact form should remain mailto or move to backend submissions.

--- a/docs/sdd/05-wireframes.md
+++ b/docs/sdd/05-wireframes.md
@@ -1,0 +1,392 @@
+# Low-Fidelity Wireframes
+
+## SDG AI Lab Website Revamp
+
+| Field | Value |
+|-------|-------|
+| **Document version** | 0.1.0 (Draft) |
+| **Date** | February 2026 |
+| **Status** | Draft -- for client review before visual design |
+
+These are text-based structural wireframes defining the layout and content placement for each key page. They should be translated into visual mockups (Figma or similar) once approved.
+
+---
+
+## Global Components
+
+### Navigation Bar
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  [Logo] SDG AI Lab          About ▾  Projects ▾  Resources      │
+│                             News     Get Involved ▾    Contact   │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- Fixed top position, white background, subtle bottom shadow
+- Logo + wordmark on left
+- Primary nav links on right
+- "About" and "Projects" have dropdown sub-menus
+- Collapses to hamburger menu on mobile (< 768px)
+- Active page indicator (underline or color highlight)
+
+### Footer
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                                                                  │
+│  [Logo] SDG AI Lab                                               │
+│  UNDP Digital, AI and Innovation Hub                             │
+│                                                                  │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐           │
+│  │ About    │ │ Projects │ │ Resources│ │ Connect  │           │
+│  │ Overview │ │ Active   │ │ Papers   │ │ Contact  │           │
+│  │ Team     │ │ Archive  │ │ Code     │ │ Volunteer│           │
+│  │ Board    │ │          │ │ Data     │ │ Newsletter│          │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘           │
+│                                                                  │
+│  [X icon] [GitHub icon] [LinkedIn icon]                          │
+│                                                                  │
+│  © 2026 SDG AI Lab. All rights reserved.                         │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Page 1: Home
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         [Navigation]                             │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│                    HERO SECTION (full-width)                      │
+│          Background: gradient or subtle animation                 │
+│                                                                  │
+│         "Harnessing the potential of                              │
+│          Artificial Intelligence for                              │
+│          Sustainable Development"                                 │
+│                                                                  │
+│         [Explore Projects]  [Get Involved]                        │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│                   IMPACT NUMBERS (3-4 cards)                      │
+│  ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐    │
+│  │  [icon]    │ │  [icon]    │ │  [icon]    │ │  [icon]    │    │
+│  │  XX+       │ │  XX+       │ │  XX+       │ │  XX+       │    │
+│  │  Projects  │ │  Volunteers│ │  Countries │ │  Partners  │    │
+│  └────────────┘ └────────────┘ └────────────┘ └────────────┘    │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│                   OUR APPROACH                                    │
+│         Brief description of methodology                         │
+│                                                                  │
+│  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐             │
+│  │  [icon]      │ │  [icon]      │ │  [icon]      │             │
+│  │  Research    │ │  Recruit &   │ │  Deliver     │             │
+│  │  Formulation │ │  Coordinate  │ │  Results     │             │
+│  │  ...         │ │  ...         │ │  ...         │             │
+│  └──────────────┘ └──────────────┘ └──────────────┘             │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│                   FEATURED PROJECTS                               │
+│                                                                  │
+│  ┌─────────────────────┐ ┌─────────────────────┐                 │
+│  │  [SDG icon badges]  │ │  [SDG icon badges]  │                 │
+│  │  Project Title      │ │  Project Title      │                 │
+│  │  Short description  │ │  Short description  │                 │
+│  │  [Learn more →]     │ │  [Learn more →]     │                 │
+│  └─────────────────────┘ └─────────────────────┘                 │
+│                                                                  │
+│                     [View all projects →]                         │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│                   PARTNERS & SUPPORTERS                           │
+│                                                                  │
+│  [logo] [logo] [logo] [logo] [logo] [logo]                      │
+│  [logo] [logo] [logo] [logo] [logo] [logo]                      │
+│                                                                  │
+│         "Grateful to the governments of our                       │
+│          fully-funded volunteers"                                 │
+│                                                                  │
+│  [flag/logo] [flag/logo] [flag/logo] [flag/logo]                 │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│                   CTA BANNER                                      │
+│          "Interested in collaborating with us?"                   │
+│          [Contact Us]  [Become a Volunteer]                       │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                         [Footer]                                 │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Mobile Layout Notes (Home)
+- Hero: stack text vertically, single CTA button, smaller font
+- Impact numbers: 2x2 grid instead of 4-across
+- Approach cards: stack vertically
+- Featured projects: single column, full-width cards
+- Partner logos: wrap to multiple rows, smaller logos
+
+---
+
+## Page 2: About > Overview
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         [Navigation]                             │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  BREADCRUMB: Home > About > Overview                             │
+│                                                                  │
+│  PAGE HEADER                                                     │
+│  "About SDG AI Lab"                                              │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌────────────────────────────┐  ┌──────────────────────┐        │
+│  │                            │  │                      │        │
+│  │  Lab description text      │  │  [Lab photo or       │        │
+│  │  (mission, history,        │  │   illustration]      │        │
+│  │   organizational           │  │                      │        │
+│  │   placement under          │  │                      │        │
+│  │   Digital, AI and          │  │                      │        │
+│  │   Innovation Hub)          │  │                      │        │
+│  │                            │  │                      │        │
+│  └────────────────────────────┘  └──────────────────────┘        │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  METHODOLOGY SECTION                                             │
+│  "Our Approach"                                                  │
+│                                                                  │
+│  1. Research formulation and solution architecture                │
+│  2. Recruit and coordinate volunteer data scientists              │
+│  3. Establish teams and coordinate workflow                       │
+│  4. Monitor R&D progress for quality                              │
+│  5. Deliver prototypes, reports, presentations                    │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  LINKS TO SUB-PAGES                                              │
+│                                                                  │
+│  ┌─────────────────┐  ┌─────────────────┐                        │
+│  │ Meet the Team → │  │ Advisory Board →│                        │
+│  └─────────────────┘  └─────────────────┘                        │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                         [Footer]                                 │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Page 3: Projects (Active)
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         [Navigation]                             │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  PAGE HEADER                                                     │
+│  "Our Projects"                                                  │
+│  Brief intro text about the lab's project areas                  │
+│                                                                  │
+│  [Active]  [Completed]    <-- tab/toggle                         │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  FILTER BAR (optional)                                           │
+│  [All SDGs ▾]  [All Topics ▾]  [Search...]                       │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  PROJECT GRID (2-3 columns)                                      │
+│                                                                  │
+│  ┌─────────────────────┐ ┌─────────────────────┐                 │
+│  │ [SDG 7] [SDG 13]    │ │ [SDG 11] [SDG 17]   │                │
+│  │ ────────────────     │ │ ────────────────     │                │
+│  │ Project Title        │ │ Project Title        │                │
+│  │                      │ │                      │                │
+│  │ Short description    │ │ Short description    │                │
+│  │ up to 2-3 lines...   │ │ up to 2-3 lines...   │               │
+│  │                      │ │                      │                │
+│  │ Status: ● Active     │ │ Status: ● Active     │                │
+│  │ [Learn more →]       │ │ [Learn more →]       │                │
+│  └─────────────────────┘ └─────────────────────┘                 │
+│                                                                  │
+│  ┌─────────────────────┐ ┌─────────────────────┐                 │
+│  │ [SDG 1] [SDG 8]     │ │ [SDG 9] [SDG 16]    │                │
+│  │ ────────────────     │ │ ────────────────     │                │
+│  │ Project Title        │ │ Project Title        │                │
+│  │ ...                  │ │ ...                  │                │
+│  └─────────────────────┘ └─────────────────────┘                 │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                         [Footer]                                 │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Mobile: single-column card stack, full-width. Filter bar collapses to icon toggle.
+
+---
+
+## Page 4: News
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         [Navigation]                             │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  PAGE HEADER                                                     │
+│  "News & Updates"                                                │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  FEATURED ARTICLE (latest, full-width)                           │
+│  ┌──────────────────────────────────────────────────────────┐    │
+│  │  [Large image]                                           │    │
+│  │  Category tag  ·  February 2026                          │    │
+│  │  "Article Title Here"                                    │    │
+│  │  Excerpt text up to 2-3 lines...                         │    │
+│  │  [Read more →]                                           │    │
+│  └──────────────────────────────────────────────────────────┘    │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ARTICLE GRID                                                    │
+│                                                                  │
+│  ┌────────────────┐ ┌────────────────┐ ┌────────────────┐        │
+│  │  [image]       │ │  [image]       │ │  [image]       │        │
+│  │  Date          │ │  Date          │ │  Date          │        │
+│  │  Title         │ │  Title         │ │  Title         │        │
+│  │  Excerpt...    │ │  Excerpt...    │ │  Excerpt...    │        │
+│  │  [Read →]      │ │  [Read →]      │ │  [Read →]      │        │
+│  └────────────────┘ └────────────────┘ └────────────────┘        │
+│                                                                  │
+│  [Load more] or pagination                                       │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                         [Footer]                                 │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Page 5: Contact
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         [Navigation]                             │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  PAGE HEADER                                                     │
+│  "Contact Us"                                                    │
+│  "Have a question or want to collaborate? Get in touch."         │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────────────────┐  ┌──────────────────────┐          │
+│  │                          │  │                      │          │
+│  │  CONTACT FORM            │  │  CONTACT INFO        │          │
+│  │                          │  │                      │          │
+│  │  Name: [____________]    │  │  Email:              │          │
+│  │  Email: [____________]   │  │  sdgailab@undp.org   │          │
+│  │  Subject: [__________]   │  │                      │          │
+│  │  Message:                │  │  Location:           │          │
+│  │  [                    ]  │  │  Istanbul, Turkey    │          │
+│  │  [                    ]  │  │                      │          │
+│  │  [                    ]  │  │  Social:             │          │
+│  │                          │  │  [X] [GitHub] [LI]   │          │
+│  │  [Send Message]          │  │                      │          │
+│  │                          │  │                      │          │
+│  └──────────────────────────┘  └──────────────────────┘          │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                         [Footer]                                 │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Form Behavior
+- Client-side validation on all required fields (name, email, message)
+- Submit to Netlify Forms (or Formspree fallback)
+- Show success message inline after submission
+- Show error message if submission fails
+- Honeypot field for spam prevention (hidden from users)
+
+---
+
+## Page 6: Get Involved > Volunteer
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         [Navigation]                             │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  PAGE HEADER                                                     │
+│  "Volunteer With Us"                                             │
+│  "Join our global network of data scientists                     │
+│   working on sustainable development challenges."                │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  HOW IT WORKS (3 steps)                                          │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐                       │
+│  │ 1. Apply │→│ 2. Match │→│ 3. Work  │                       │
+│  │ Submit   │  │ Get      │  │ Join a   │                       │
+│  │ your     │  │ matched  │  │ project  │                       │
+│  │ profile  │  │ to a     │  │ team and │                       │
+│  │          │  │ project  │  │ deliver  │                       │
+│  └──────────┘  └──────────┘  └──────────┘                       │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  WHAT WE LOOK FOR                                                │
+│  - Data science / ML skills                                      │
+│  - Commitment of X hours/week                                    │
+│  - Interest in sustainable development                           │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  APPLICATION FORM                                                │
+│  Name, Email, LinkedIn, Skills, Availability, Motivation         │
+│  [Submit Application]                                            │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                         [Footer]                                 │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Responsive Breakpoints
+
+| Breakpoint | Width | Layout Changes |
+|------------|-------|---------------|
+| Mobile | < 640px | Single column, hamburger nav, stacked cards |
+| Tablet | 640px - 1024px | 2-column grids, expanded nav with dropdowns |
+| Desktop | > 1024px | Full layout as shown in wireframes above |
+
+---
+
+## Design Tokens (to be refined in visual design phase)
+
+| Token | Proposed Value | Notes |
+|-------|---------------|-------|
+| Primary color | UNDP Blue (#0468B1) or current dark blue | Confirm with UNDP branding (Q1.4) |
+| Secondary color | SDG-related accent | TBD |
+| Background | White (#FFFFFF) / Light gray (#F8F9FA) | Clean, professional |
+| Text | Dark gray (#1A1A2E) | High contrast for accessibility |
+| Font family | Open Sans (current) or Inter | Confirm preference |
+| Base font size | 16px | Standard for readability |
+| Border radius | 8px (cards), 4px (buttons) | Modern but not overly rounded |
+| Spacing scale | 4px base unit (4, 8, 12, 16, 24, 32, 48, 64) | Consistent vertical rhythm |
+
+---
+
+_These wireframes will be translated into visual mockups once the client confirms the sitemap and design direction. The visual design phase will produce high-fidelity Figma files for each page and responsive breakpoint._

--- a/docs/sdd/06-project-scaffold.md
+++ b/docs/sdd/06-project-scaffold.md
@@ -1,0 +1,410 @@
+# Project Scaffold Specification
+
+## SDG AI Lab Website Revamp
+
+| Field | Value |
+|-------|-------|
+| **Document version** | 0.1.0 (Draft) |
+| **Date** | February 2026 |
+| **Status** | Ready to execute once tech stack is confirmed |
+
+---
+
+## 1. Prerequisites
+
+Before scaffolding, ensure the following are confirmed:
+
+- [ ] Framework decision (ADR-001) -- default: Astro
+- [ ] Hosting decision (ADR-002) -- **GitHub Pages**
+- [ ] CSS decision (ADR-003) -- default: Tailwind CSS
+- [ ] CMS decision (ADR-005) -- **Supabase-backed**
+- [ ] Analytics decision (ADR-006) -- **Google Analytics 4** (and cookie consent if required)
+- [ ] Node.js 18+ installed
+- [ ] Git configured with access to SDG-AI-Lab/sdgailab.github.io
+
+---
+
+## 2. Branch Strategy
+
+```
+main              ← production (current live site, do not touch until launch)
+  └── new-version ← integration branch for the revamp
+       ├── feat/* ← feature branches (one per page or feature)
+       └── fix/*  ← bug fix branches
+```
+
+All work happens on `new-version` or feature branches off of it. The `main` branch remains the live site until the revamp is launched.
+
+---
+
+## 3. Scaffold Commands
+
+### 3.1 Initialize Astro Project
+
+```bash
+# From the repository root, on the new-version branch
+npm create astro@latest . -- --template minimal --no-install
+
+# Install dependencies
+npm install
+
+# Add Tailwind CSS integration
+npx astro add tailwind
+
+# Add sitemap integration (for SEO)
+npx astro add sitemap
+```
+
+### 3.2 Install Additional Dependencies
+
+```bash
+# Icons (tree-shakeable SVG icons)
+npm install lucide-astro
+
+# Self-hosted fonts (eliminates Google Fonts CDN dependency)
+npm install @fontsource/open-sans
+
+# Supabase client (for runtime reads)
+npm install @supabase/supabase-js
+
+# Prettier + Astro plugin for formatting
+npm install -D prettier prettier-plugin-astro prettier-plugin-tailwindcss
+
+# ESLint for linting
+npm install -D eslint @eslint/js
+```
+
+### 3.3 Optional Dependencies (based on client decisions)
+
+```bash
+# If hosting on GitHub Pages:
+npx astro add @astrojs/github-pages
+```
+
+---
+
+## 4. Project Structure
+
+This structure assumes **GitHub Pages hosting** and a **Supabase-backed CMS** as the system of record, with **runtime reads** so non-technical editors see changes immediately after publishing in Supabase (no redeploy).
+
+```
+sdgailab.github.io/
+├── src/
+│   ├── components/          # Reusable UI components
+│   │   ├── Navigation.astro
+│   │   ├── Footer.astro
+│   │   ├── Hero.astro
+│   │   ├── ProjectCard.astro
+│   │   ├── TeamMember.astro
+│   │   ├── PartnerLogo.astro
+│   │   ├── NewsCard.astro
+│   │   ├── ContactForm.astro
+│   │   ├── ImpactCounter.astro
+│   │   └── SdgBadge.astro
+│   │
+│   ├── layouts/             # Page layout templates
+│   │   ├── BaseLayout.astro  # HTML head, nav, footer, analytics
+│   │   └── ArticleLayout.astro # Layout for news articles
+│   │
+│   ├── pages/               # Route-based pages (file = URL)
+│   │   ├── index.astro       # Home (/)
+│   │   ├── about/
+│   │   │   ├── index.astro   # About Overview (/about)
+│   │   │   ├── team.astro    # Team (/about/team)
+│   │   │   └── advisory-board.astro # Board (/about/advisory-board)
+│   │   ├── projects/
+│   │   │   ├── index.astro   # Active Projects (/projects)
+│   │   │   ├── completed.astro # Completed (/projects/completed)
+│   │   │   └── [slug].astro  # Individual project (/projects/[slug])
+│   │   ├── resources/
+│   │   │   ├── index.astro   # Resources overview (/resources)
+│   │   │   ├── publications.astro
+│   │   │   └── open-source.astro
+│   │   ├── news/
+│   │   │   ├── index.astro   # News list (/news)
+│   │   │   └── [slug].astro  # Individual article (/news/[slug])
+│   │   ├── get-involved/
+│   │   │   ├── volunteer.astro
+│   │   │   └── partner.astro
+│   │   └── contact.astro     # Contact form (/contact)
+│   │
+│   ├── data/                # Local types + defaults (optional)
+│   │   └── schema.ts         # Shared TS types mirroring Supabase tables
+│   │
+│   ├── lib/                 # Data access utilities
+│   │   └── supabase.ts       # Supabase client (browser-safe; anon key)
+│   │
+│   ├── islands/             # Client-side components (Astro islands)
+│   │   ├── ProjectsGrid.tsx  # Fetch + render projects from Supabase
+│   │   ├── NewsGrid.tsx      # Fetch + render news from Supabase
+│   │   └── PartnersGrid.tsx  # Fetch + render partner logos from Supabase
+│   │
+│   └── styles/              # Global styles
+│       └── global.css        # Tailwind directives + custom base styles
+│
+├── public/                  # Static assets (copied as-is to build output)
+│   ├── images/
+│   │   ├── logos/            # Partner logos
+│   │   ├── team/             # Team member photos
+│   │   ├── board/            # Board member photos
+│   │   └── news/             # News article images
+│   ├── fonts/                # Self-hosted font files (if not using @fontsource)
+│   └── favicon.ico           # (migrate from icons/ directory)
+│
+├── docs/                    # SDD documentation (this directory)
+│   └── sdd/
+│
+├── astro.config.mjs         # Astro configuration
+├── tailwind.config.mjs      # Tailwind configuration (design tokens)
+├── tsconfig.json            # TypeScript config
+├── package.json
+├── .prettierrc              # Prettier config
+├── .eslintrc.js             # ESLint config
+├── .gitignore               # Updated for Astro
+├── CNAME                    # Retain for domain mapping
+└── README.md                # Updated project documentation
+```
+
+---
+
+## 5. Configuration Files
+
+### 5.1 astro.config.mjs
+
+```javascript
+import { defineConfig } from 'astro/config';
+import tailwind from '@astrojs/tailwind';
+import sitemap from '@astrojs/sitemap';
+
+export default defineConfig({
+  site: 'https://sdgailab.org',
+  integrations: [tailwind(), sitemap()],
+  output: 'static',
+});
+```
+
+### 5.2 tailwind.config.mjs
+
+```javascript
+export default {
+  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#eff6ff',
+          100: '#dbeafe',
+          500: '#0468B1',  // UNDP Blue (adjust per branding guidelines)
+          600: '#035d9e',
+          700: '#024e85',
+          800: '#013f6b',
+          900: '#003052',
+        },
+      },
+      fontFamily: {
+        sans: ['"Open Sans"', 'system-ui', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+};
+```
+
+### 5.3 GitHub Pages deployment
+
+Use the GitHub Pages adapter (`@astrojs/github-pages`) and a GitHub Actions workflow that builds and deploys the static site. Supabase data is fetched at runtime in the browser, so no CI secrets are required for content reads (the anon key is public and protected by RLS).
+
+### 5.4 .prettierrc
+
+```json
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "plugins": ["prettier-plugin-astro", "prettier-plugin-tailwindcss"],
+  "overrides": [
+    {
+      "files": "*.astro",
+      "options": {
+        "parser": "astro"
+      }
+    }
+  ]
+}
+```
+
+### 5.5 .gitignore (Astro additions)
+
+```
+# Astro
+dist/
+.astro/
+
+# Dependencies
+node_modules/
+
+# Environment
+.env
+.env.*
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Build
+*.log
+```
+
+---
+
+## 6. Content Collection Schemas
+
+### src/content/config.ts
+
+```typescript
+import { defineCollection, z } from 'astro:content';
+
+const projects = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    status: z.enum(['active', 'completed']),
+    sdgGoals: z.array(z.number().min(1).max(17)),
+    startDate: z.date(),
+    endDate: z.date().optional(),
+    featured: z.boolean().default(false),
+    order: z.number().default(0),
+  }),
+});
+
+const news = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    date: z.date(),
+    author: z.string().optional(),
+    excerpt: z.string(),
+    image: z.string().optional(),
+    category: z.string().optional(),
+    externalUrl: z.string().url().optional(),
+    featured: z.boolean().default(false),
+  }),
+});
+
+const team = defineCollection({
+  type: 'content',
+  schema: z.object({
+    name: z.string(),
+    title: z.string(),
+    photo: z.string().optional(),
+    stream: z.enum(['management', 'technical', 'operational', 'professional']),
+    order: z.number().default(0),
+  }),
+});
+
+const board = defineCollection({
+  type: 'content',
+  schema: z.object({
+    name: z.string(),
+    title: z.string(),
+    affiliation: z.string().optional(),
+    photo: z.string().optional(),
+    order: z.number().default(0),
+  }),
+});
+
+export const collections = { projects, news, team, board };
+```
+
+---
+
+## 7. CI/CD Pipeline
+
+### 7.1 Netlify (Primary)
+
+Netlify automatically builds and deploys on every push. Deploy previews are generated for every PR. No additional configuration needed beyond `netlify.toml`.
+
+### 7.2 GitHub Actions (Fallback -- for GitHub Pages)
+
+Create `.github/workflows/deploy.yml`:
+
+```yaml
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+---
+
+## 8. npm Scripts
+
+```json
+{
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "format": "prettier --write .",
+    "lint": "eslint src/",
+    "check": "astro check"
+  }
+}
+```
+
+---
+
+## 9. Migration Checklist
+
+When scaffolding the new project, migrate these assets from the current site:
+
+- [ ] Logo image (`assets/img/Webp.net-resizeimage.jpg`) → `public/images/logo.jpg`
+- [ ] Hero image (`assets/img/Webp.net-resizeimage.png`) → `public/images/hero.png` (if keeping)
+- [ ] Partner logos (`assets/img/logos/`) → `public/images/logos/`
+- [ ] Board member photos → `public/images/board/`
+- [ ] News images → `public/images/news/`
+- [ ] Favicon set (`icons/`) → `public/` (rename/restructure)
+- [ ] CNAME file → keep at root
+- [ ] Content text from each HTML page → Markdown files in `src/content/`
+
+---
+
+_Execute this scaffold once the tech stack decisions in ADR-001 through ADR-007 are confirmed by the client._

--- a/docs/sdd/07-content-pipeline.md
+++ b/docs/sdd/07-content-pipeline.md
@@ -1,0 +1,185 @@
+# Content Pipeline Tracker
+
+## SDG AI Lab Website Revamp
+
+| Field | Value |
+|-------|-------|
+| **Document version** | 0.1.0 (Draft) |
+| **Date** | February 2026 |
+| **Status** | Template -- assign owners and due dates once client responds |
+
+---
+
+## 1. Content Delivery Process
+
+```
+Request → Draft → Review → Approve → Integrate → Verify
+```
+
+1. **Request:** Dev team identifies content needed (this tracker)
+2. **Draft:** Content owner writes/provides the content
+3. **Review:** Stakeholders review for accuracy and tone
+4. **Approve:** Decision maker signs off
+5. **Integrate:** Dev team adds content to the site (Markdown files or CMS)
+6. **Verify:** Content owner verifies the live rendering
+
+---
+
+## 2. Content Inventory and Status
+
+### 2.1 Homepage Content
+
+| Item | Current State | Action Needed | Owner | Due Date | Status |
+|------|--------------|---------------|-------|----------|--------|
+| Hero tagline | "Harnessing the potential of AI for Sustainable Development" | Confirm or update | _TBD_ | _TBD_ | Pending |
+| Hero CTA buttons | None (no CTAs currently) | Write CTA text, decide destinations | _TBD_ | _TBD_ | Pending |
+| "Our Approach" section | 5-point methodology description | Review and update | _TBD_ | _TBD_ | Pending |
+| Impact numbers | Not present | Provide metrics (projects count, volunteer count, countries, partners) | _TBD_ | _TBD_ | Pending |
+| "Volunteer Data Scientist Initiative" | 4 feature boxes with descriptions | Review and update | _TBD_ | _TBD_ | Pending |
+| Partner logos | 12 logos (8 partners + 4 government supporters) | Verify current list; provide new logos if any | _TBD_ | _TBD_ | Pending |
+| Featured projects | Not present (new section) | Select 2-3 projects to highlight | _TBD_ | _TBD_ | Pending |
+
+### 2.2 About Page Content
+
+| Item | Current State | Action Needed | Owner | Due Date | Status |
+|------|--------------|---------------|-------|----------|--------|
+| Lab description | ~2021 text, updated to mention 2025 Hub change | Full review and rewrite | _TBD_ | _TBD_ | Pending |
+| Organizational placement | Mentions BPPS, Sustainable Finance Hub, IICPSD | Confirm current org structure post-2025 | _TBD_ | _TBD_ | Pending |
+| Lab history / timeline | Not present | Provide key milestones (2019-2026) | _TBD_ | _TBD_ | Pending |
+| Methodology | Same content as homepage "Our Approach" | Decide if expanded version is needed | _TBD_ | _TBD_ | Pending |
+
+### 2.3 Team Content
+
+| Item | Current State | Action Needed | Owner | Due Date | Status |
+|------|--------------|---------------|-------|----------|--------|
+| Team member names | Not listed (roles only) | Provide names (if approved in Q2.5) | _TBD_ | _TBD_ | Pending |
+| Team member photos | Not present | Provide headshots (min 400x400px, JPG/PNG) | _TBD_ | _TBD_ | Pending |
+| Team member bios | Not present | Write 2-3 sentence bios per person | _TBD_ | _TBD_ | Pending |
+| Team member titles | Generic ("Technical Advisor", "Onsite Data Scientists") | Provide current, accurate titles | _TBD_ | _TBD_ | Pending |
+| Organizational chart | Not present | Decide if needed; provide structure | _TBD_ | _TBD_ | Pending |
+
+### 2.4 Advisory Board Content
+
+| Member | Photo | Title Current? | Bio Needed? | Owner | Due Date | Status |
+|--------|-------|---------------|-------------|-------|----------|--------|
+| Boris Alberda | Yes | _Verify_ | _TBD_ | _TBD_ | _TBD_ | Pending |
+| Hande Bilir | Yes | _Verify_ | _TBD_ | _TBD_ | _TBD_ | Pending |
+| Samira Khan | Yes | _Verify_ | _TBD_ | _TBD_ | _TBD_ | Pending |
+| Soonson Kwon | Yes | _Verify_ | _TBD_ | _TBD_ | _TBD_ | Pending |
+| Prof. Ebru Akcapinar Sezer | Yes | _Verify_ | _TBD_ | _TBD_ | _TBD_ | Pending |
+| Dr. Serdar Turkeli | Yes | _Verify_ | _TBD_ | _TBD_ | _TBD_ | Pending |
+| Natalia Villalobos | Yes | _Verify_ | _TBD_ | _TBD_ | _TBD_ | Pending |
+| Prof. Deniz Yuret | Yes | _Verify_ | _TBD_ | _TBD_ | _TBD_ | Pending |
+| _New members (if any)_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | _TBD_ | Pending |
+
+### 2.5 Project Content
+
+| Project | Current State | Action Needed | Owner | Due Date | Status |
+|---------|--------------|---------------|-------|----------|--------|
+| Nature, Energy, Climate Cluster | ~2021 description | Confirm active/completed; update description | _TBD_ | _TBD_ | Pending |
+| Connecting Business Initiative | ~2021 description | Confirm active/completed; update description | _TBD_ | _TBD_ | Pending |
+| Business Call to Action | ~2021 description | Confirm active/completed; update description | _TBD_ | _TBD_ | Pending |
+| PPMI/OSDG | ~2021 description | Confirm active/completed; update description | _TBD_ | _TBD_ | Pending |
+| Internal Work Streams | ~2021 description (mentions "Twitter analysis") | Confirm active/completed; update description | _TBD_ | _TBD_ | Pending |
+| _New project 1_ | Not present | Provide title, description, SDG goals, status | _TBD_ | _TBD_ | Pending |
+| _New project 2_ | Not present | Provide title, description, SDG goals, status | _TBD_ | _TBD_ | Pending |
+| _New project N_ | Not present | Provide title, description, SDG goals, status | _TBD_ | _TBD_ | Pending |
+
+**Per project, we need:**
+- Title
+- Description (2-4 paragraphs)
+- SDG goal tags (which of Goals 1-17 does it address)
+- Status (active / completed)
+- Start date and end date (if completed)
+- Key outcomes (if completed)
+- Featured flag (should it appear on homepage?)
+
+### 2.6 News / Articles Content
+
+| Article | Current State | Action Needed | Owner | Due Date | Status |
+|---------|--------------|---------------|-------|----------|--------|
+| "Our Approach" (Nov 2020) | External link to IICPSD | Decide: keep, update, or remove | _TBD_ | _TBD_ | Pending |
+| "UNV Partnership" (Sep 2020) | External link | Decide: keep, update, or remove | _TBD_ | _TBD_ | Pending |
+| "ML for SDGs" (Jul 2020) | External link | Decide: keep, update, or remove | _TBD_ | _TBD_ | Pending |
+| "OSDG Launch" (Oct 2020) | External link | Decide: keep, update, or remove | _TBD_ | _TBD_ | Pending |
+| "Digital Transformation" (Jun 2021) | External link | Decide: keep, update, or remove | _TBD_ | _TBD_ | Pending |
+| _New articles (2022-2026)_ | Not present | Provide or identify recent news | _TBD_ | _TBD_ | Pending |
+
+### 2.7 Contact Page Content
+
+| Item | Current State | Action Needed | Owner | Due Date | Status |
+|------|--------------|---------------|-------|----------|--------|
+| Contact email | sdgailab@undp.org | Confirm still active | _TBD_ | _TBD_ | Pending |
+| Physical address | Not displayed (Istanbul, Turkey implied) | Provide if should be shown | _TBD_ | _TBD_ | Pending |
+| Phone number | Not present | Provide if should be shown | _TBD_ | _TBD_ | Pending |
+| Form recipient | Currently mailto:sdgailab@undp.org | Confirm who should receive form submissions | _TBD_ | _TBD_ | Pending |
+
+### 2.8 Global / Cross-Page Content
+
+| Item | Current State | Action Needed | Owner | Due Date | Status |
+|------|--------------|---------------|-------|----------|--------|
+| Site logo | `Webp.net-resizeimage.jpg` (poor filename) | Confirm or provide updated logo (SVG preferred) | _TBD_ | _TBD_ | Pending |
+| Favicon | Present (icons/ directory) | Confirm or provide updated favicon | _TBD_ | _TBD_ | Pending |
+| Meta description (site-wide) | Not present | Write 150-160 character description | _TBD_ | _TBD_ | Pending |
+| OG image (social sharing) | Not present | Provide or create (1200x630px) | _TBD_ | _TBD_ | Pending |
+| Social media URLs | Twitter: @sdgailab, GitHub: SDG-AI-Lab | Confirm all channels; provide URLs | _TBD_ | _TBD_ | Pending |
+| Copyright text | "© [year] SDG AI Lab" | Confirm wording | _TBD_ | _TBD_ | Pending |
+| UNDP Hub attribution | "UNDP's Digital, AI and Innovation Hub" (in About text) | Provide approved attribution text for footer | _TBD_ | _TBD_ | Pending |
+
+### 2.9 New Sections (if approved by client)
+
+| Section | Content Needed | Owner | Due Date | Status |
+|---------|---------------|-------|----------|--------|
+| Volunteer page | Program description, requirements, benefits, application form fields | _TBD_ | _TBD_ | Pending |
+| Resources / Publications | List of publications with titles, authors, dates, abstracts, links | _TBD_ | _TBD_ | Pending |
+| Open Source | List of GitHub repositories with descriptions | _TBD_ | _TBD_ | Pending |
+| Impact metrics | Numbers for: projects, volunteers, countries, partners | _TBD_ | _TBD_ | Pending |
+
+---
+
+## 3. Image / Asset Requirements
+
+| Asset Type | Specs | Format | Where Needed |
+|-----------|-------|--------|-------------|
+| Site logo | Vector preferred | SVG (primary), PNG fallback | Nav, footer, OG image |
+| Team photos | Min 400x400px, square crop | JPG or PNG, < 200KB each | Team page |
+| Board photos | Min 400x400px, square crop | JPG or PNG, < 200KB each | Advisory Board page |
+| Partner logos | Transparent background, consistent height (~80px) | PNG or SVG | Home, About |
+| News images | 800x450px (16:9 aspect) | JPG, < 300KB each | News list, article pages |
+| OG image | 1200x630px | PNG or JPG | Social sharing meta tags |
+| Favicon | 32x32 and 180x180 (Apple touch) | PNG + ICO | All pages (browser tab) |
+| SDG icons | Official UN SDG icons (Goals 1-17) | SVG | Project cards |
+
+---
+
+## 4. Content Delivery Timeline
+
+> _To be filled in once client confirms timeline (Q6.1) and content owners (Q6.5)._
+
+| Phase | Content Deliverables | Target Date |
+|-------|---------------------|-------------|
+| **Phase 0: Verification** | Confirm all existing content (advisory board, projects, partners) | _TBD_ |
+| **Phase 1: Core pages** | Homepage text, About text, updated project descriptions, contact info | _TBD_ |
+| **Phase 2: People** | Team bios + photos, verified board member info | _TBD_ |
+| **Phase 3: Media** | Updated logos, OG image, news articles | _TBD_ |
+| **Phase 4: New sections** | Volunteer page content, publications list, impact metrics | _TBD_ |
+
+---
+
+## 5. Content Review Checklist
+
+Before any content goes live, verify:
+
+- [ ] Factual accuracy (names, titles, dates, statistics)
+- [ ] Spelling and grammar
+- [ ] Consistent tone and voice
+- [ ] No broken links
+- [ ] Images are optimized (compressed, correct dimensions)
+- [ ] Alt text provided for all images
+- [ ] Meta descriptions written for the page
+- [ ] OG tags set (title, description, image)
+- [ ] Content approved by designated stakeholder
+
+---
+
+_This tracker will be updated with assigned owners and due dates once the client identifies their content team (Q6.5) and confirms the timeline (Q6.1)._

--- a/docs/sdd/08-detailed-spec.md
+++ b/docs/sdd/08-detailed-spec.md
@@ -1,0 +1,493 @@
+# Detailed Specification (SDD)
+
+## SDG AI Lab Website Revamp
+
+| Field | Value |
+|-------|-------|
+| **Document version** | 0.1.0 (Draft) |
+| **Date** | February 2026 |
+| **Status** | Draft -- acceptance criteria to be validated after client input |
+
+---
+
+## Overview
+
+This document specifies the functional behavior, content requirements, and acceptance criteria for each page and feature of the revamped SDG AI Lab website. It is the core artifact of the Spec Driven Development (SDD) process: each item here will be built to this spec, reviewed against these criteria, and signed off before moving to the next.
+
+**References:**
+- [PRD](02-product-requirements-document.md) -- requirements and constraints
+- [IA](03-information-architecture.md) -- sitemap and navigation
+- [ADR](04-architecture-decision-record.md) -- tech stack decisions
+- [Wireframes](05-wireframes.md) -- structural layouts
+- [Scaffold](06-project-scaffold.md) -- project setup
+- [Content Pipeline](07-content-pipeline.md) -- content delivery tracker
+
+---
+
+## SPEC-001: Base Layout
+
+### Purpose
+Shared HTML structure wrapping every page: `<head>` metadata, navigation, footer, analytics script, and global styles.
+
+### Requirements
+- Render correct `<title>` per page (format: `Page Name - SDG AI Lab`)
+- Include meta description per page (unique, 150-160 characters)
+- Include Open Graph tags: `og:title`, `og:description`, `og:image`, `og:url`, `og:type`
+- Include Twitter Card tags: `twitter:card`, `twitter:site`, `twitter:title`, `twitter:description`, `twitter:image`
+- Include canonical URL
+- Include favicon references (ICO, 32x32 PNG, Apple touch icon)
+- Include self-hosted Open Sans font via `@fontsource`
+- Include Plausible analytics script (or chosen analytics)
+- Render Navigation component
+- Render Footer component
+- Render `<main>` content slot between nav and footer
+- Apply Tailwind base styles
+- Support light mode (dark mode as future enhancement)
+
+### Acceptance Criteria
+- [ ] Every page passes Lighthouse SEO audit with score >= 90
+- [ ] Every page has unique, non-empty `<title>` and `meta description`
+- [ ] OG tags render correctly when URL is pasted into Slack, Twitter/X, LinkedIn
+- [ ] Favicon displays in browser tab across Chrome, Firefox, Safari, Edge
+- [ ] Font renders as Open Sans on first paint (no FOUT/FOIT flash)
+- [ ] Analytics script loads and records page views
+- [ ] HTML validates with no errors (W3C validator)
+
+---
+
+## SPEC-002: Navigation Component
+
+### Purpose
+Global navigation bar providing access to all top-level sections.
+
+### Requirements
+- Fixed to top of viewport on scroll
+- Left: logo image + "SDG AI Lab" wordmark (links to home)
+- Right: nav links -- About (dropdown), Projects (dropdown), Resources, News, Get Involved (dropdown), Contact
+- Dropdown sub-items as defined in IA Section 3
+- Active page/section highlighted
+- Collapse to hamburger menu below 768px
+- Hamburger opens full-height mobile menu with accordion sub-items
+- Skip-to-content link for accessibility (visually hidden, visible on focus)
+
+### Acceptance Criteria
+- [ ] Logo links to homepage from every page
+- [ ] Active page link is visually distinguished (underline, color, or weight)
+- [ ] Dropdowns open on hover (desktop) and click (mobile/touch)
+- [ ] Hamburger menu opens/closes with animation on mobile
+- [ ] Mobile menu sub-items expand/collapse on tap
+- [ ] Keyboard navigable: Tab through links, Enter/Space to activate, Escape to close dropdowns
+- [ ] ARIA attributes: `aria-expanded`, `aria-haspopup`, `aria-current="page"`
+- [ ] Navigation is identical in structure across all pages (rendered from shared component)
+
+---
+
+## SPEC-003: Footer Component
+
+### Purpose
+Global footer with navigation links, social media icons, and legal text.
+
+### Requirements
+- 4-column link grid: About, Projects, Resources, Connect
+- Social media icons: X (Twitter), GitHub, LinkedIn (confirm with client)
+- Attribution line: "UNDP Digital, AI and Innovation Hub"
+- Copyright: "© [dynamic year] SDG AI Lab"
+- Links open in the same tab (internal) or new tab (external, with `rel="noopener noreferrer"`)
+
+### Acceptance Criteria
+- [ ] All footer links resolve to correct pages (no 404s)
+- [ ] External links open in new tab with `rel="noopener noreferrer"`
+- [ ] Social icons link to correct profiles
+- [ ] Copyright year updates automatically (client-side JS or build-time)
+- [ ] Footer is visually consistent across all pages
+
+---
+
+## SPEC-004: Home Page
+
+### Purpose
+First impression. Communicate the lab's mission, showcase impact, highlight key projects, display partners, and drive visitors toward primary CTAs.
+
+### Sections (in order)
+
+#### 4.1 Hero
+- Background: gradient, subtle animation, or static image (replacing particles.js -- confirm with client)
+- Headline: primary tagline (content from pipeline)
+- Sub-headline: one sentence describing the lab
+- CTA buttons: "Explore Projects" (→ /projects), "Get Involved" (→ /get-involved/volunteer)
+
+#### 4.2 Impact Numbers
+- 3-4 metric cards with icon, number, and label
+- Numbers can be static or animated (count-up on scroll into view)
+- Content: projects count, volunteer count, countries reached, partners count
+
+#### 4.3 Our Approach
+- Section heading
+- Brief intro paragraph
+- 3-5 methodology cards (icon + short description)
+
+#### 4.4 Featured Projects
+- Section heading
+- 2-3 project cards (pulled from content collection, filtered by `featured: true`)
+- Each card: SDG badges, title, excerpt, "Learn more" link
+- "View all projects" link at bottom
+
+#### 4.5 Partners & Supporters
+- Section heading
+- Logo grid: partner logos in rows (auto-wrap)
+- Government supporters sub-section with attribution text
+- Each logo links to partner website (new tab)
+
+#### 4.6 CTA Banner
+- Background: contrasting color
+- Headline: "Interested in collaborating?"
+- Two buttons: "Contact Us" (→ /contact), "Become a Volunteer" (→ /get-involved/volunteer)
+
+### Acceptance Criteria
+- [ ] Hero renders without layout shift on load
+- [ ] CTA buttons navigate to correct pages
+- [ ] Impact numbers display correctly (no NaN, no missing values)
+- [ ] Featured project cards pull from content collection (not hard-coded HTML)
+- [ ] All partner logos display, are clickable, and open correct URLs in new tabs
+- [ ] Page loads in < 3 seconds on simulated 3G (Lighthouse)
+- [ ] Lighthouse Performance score >= 85
+- [ ] All images have alt text
+- [ ] Mobile layout matches wireframe: stacked sections, 2x2 impact grid, single-column cards
+
+---
+
+## SPEC-005: About > Overview Page
+
+### Purpose
+Explain what the lab is, its history, organizational placement, and methodology.
+
+### Requirements
+- Breadcrumb: Home > About > Overview
+- Lab description (2-3 paragraphs, from content pipeline)
+- Optional: photo or illustration alongside text
+- Methodology section (expanded version of homepage approach)
+- Navigation cards to Team and Advisory Board sub-pages
+
+### Acceptance Criteria
+- [ ] Breadcrumb links are functional
+- [ ] Text content matches approved copy from content pipeline
+- [ ] Cards link to /about/team and /about/advisory-board
+- [ ] Page is accessible: heading hierarchy (h1 > h2 > h3), sufficient color contrast
+
+---
+
+## SPEC-006: About > Team Page
+
+### Purpose
+Display named team members with photos, titles, and bios (if approved by client).
+
+### Requirements
+- Grid of team member cards
+- Each card: photo (circular crop), name, title, stream label, short bio
+- Grouped by stream: Management, Technical, Operational, Professional
+- Pulled from `team` content collection
+- Fallback: if client prefers roles-only (no names), display role cards without personal details
+
+### Acceptance Criteria
+- [ ] Team members render from content collection, sorted by `order` field
+- [ ] Stream grouping is visually clear (section headings or visual separators)
+- [ ] Photos are lazy-loaded with `loading="lazy"`
+- [ ] All photos have alt text: "{name}, {title}"
+- [ ] Page renders gracefully with 0 team members (shows "Coming soon" message)
+
+---
+
+## SPEC-007: About > Advisory Board Page
+
+### Purpose
+Display advisory board members with photos, names, titles, and affiliations.
+
+### Requirements
+- Grid of board member cards
+- Each card: photo, name, title, affiliation, optional short bio
+- Pulled from `board` content collection
+- Cards are consistent in size regardless of content length
+
+### Acceptance Criteria
+- [ ] Board members render from content collection, sorted by `order` field
+- [ ] All 8 current members display (updated per client verification)
+- [ ] Photos display at consistent dimensions
+- [ ] Responsive: 3 columns desktop, 2 tablet, 1 mobile
+
+---
+
+## SPEC-008: Projects Page
+
+### Purpose
+Showcase the lab's active and completed projects with SDG tagging.
+
+### Requirements
+- Tab/toggle: "Active" (default) and "Completed"
+- Project cards pulled from `projects` content collection
+- Each card: SDG goal badges, title, description excerpt, status indicator, "Learn more" link
+- Optional filter bar: filter by SDG goal or topic
+- Active tab shows projects where `status: 'active'`
+- Completed tab shows projects where `status: 'completed'`
+
+### Acceptance Criteria
+- [ ] Active/Completed toggle works without page reload (client-side)
+- [ ] Project cards pull from content collection (not hard-coded)
+- [ ] SDG badges display correct goal icons with tooltips ("Goal X: Name")
+- [ ] Status indicator: green dot for active, gray for completed
+- [ ] "Learn more" links to individual project page (/projects/[slug])
+- [ ] Responsive: 2 columns desktop, 1 column mobile
+- [ ] Page shows meaningful state when 0 projects exist in a category
+
+---
+
+## SPEC-009: Individual Project Page
+
+### Purpose
+Deep-dive into a single project with full description, SDG alignment, and outcomes.
+
+### Requirements
+- Breadcrumb: Home > Projects > [Project Title]
+- Full project description (Markdown body from content collection)
+- SDG goal badges with full goal names
+- Status, date range
+- Outcomes section (if completed)
+- "Back to Projects" link
+- Optional: related projects sidebar
+
+### Acceptance Criteria
+- [ ] Dynamic route renders correct project based on URL slug
+- [ ] Markdown content renders correctly (headings, lists, links, images)
+- [ ] 404 page displayed for non-existent project slugs
+- [ ] Breadcrumb links are functional
+- [ ] Page has unique meta description and OG tags
+
+---
+
+## SPEC-010: News Page
+
+### Purpose
+Display news articles in reverse chronological order.
+
+### Requirements
+- Featured article at top (latest or manually flagged)
+- Article grid below (3 columns desktop, 1 mobile)
+- Each card: image, date, category tag, title, excerpt, "Read more" link
+- If article has `externalUrl`, "Read more" opens external URL in new tab
+- If article is hosted on-site, "Read more" links to /news/[slug]
+- Pagination or "Load more" if > 9 articles
+
+### Acceptance Criteria
+- [ ] Articles sorted by date, newest first
+- [ ] Featured article is visually distinct (larger card, full-width)
+- [ ] External links open in new tab with `rel="noopener noreferrer"`
+- [ ] Date format is consistent: "Month DD, YYYY"
+- [ ] Page shows meaningful state with 0 articles
+- [ ] Pagination works correctly if implemented
+
+---
+
+## SPEC-011: Contact Page
+
+### Purpose
+Enable visitors to send messages to the SDG AI Lab team.
+
+### Requirements
+- Contact form: Name (required), Email (required), Subject (optional), Message (required)
+- Form submits to backend (Netlify Forms or Formspree, per ADR-004)
+- Honeypot field for spam prevention (hidden from users, visible to bots)
+- Client-side validation with clear error messages
+- Success state: inline confirmation message after submission
+- Error state: inline error message with retry option
+- Sidebar or section: direct email, location (Istanbul, Turkey), social links
+
+### Acceptance Criteria
+- [ ] Form submits successfully and data reaches the configured backend
+- [ ] Validation prevents submission with empty required fields
+- [ ] Email field validates email format
+- [ ] Honeypot field is hidden via CSS (not `display:none` which bots detect, but off-screen positioning)
+- [ ] Success message appears after submission without page reload
+- [ ] Error message appears if submission fails
+- [ ] Form is keyboard-accessible: Tab through fields, Enter to submit
+- [ ] Labels are associated with inputs via `for`/`id` attributes
+- [ ] Form works without JavaScript (progressive enhancement: falls back to standard form POST)
+
+---
+
+## SPEC-012: Volunteer Page
+
+### Purpose
+Recruit volunteer data scientists by explaining the program and providing an application pathway.
+
+### Requirements
+- Program description: what volunteers do, time commitment, benefits
+- "How it works" step-by-step (3 steps, per wireframe)
+- Requirements section: skills, availability, interest areas
+- Application form or link to external application (UNV platform)
+- If form: Name, Email, LinkedIn URL, Skills (multi-select or text), Availability, Motivation (textarea)
+
+### Acceptance Criteria
+- [ ] Page clearly communicates what is expected of volunteers
+- [ ] Application form submits successfully (or external link works)
+- [ ] Form fields have appropriate validation
+- [ ] Page is accessible and mobile-friendly
+- [ ] "How it works" section is visually engaging (icons, step indicators)
+
+---
+
+## SPEC-013: Resources Page (if approved)
+
+### Purpose
+Surface the lab's publications, open-source tools, and datasets.
+
+### Requirements
+- Sub-sections: Publications, Open Source, Datasets (or tabs)
+- Publications: list with title, authors, date, abstract snippet, download/link
+- Open Source: repository cards with name, description, stars, language, link to GitHub
+- Datasets: name, description, format, download/link
+
+### Acceptance Criteria
+- [ ] Content renders from Markdown files or data files (not hard-coded)
+- [ ] External links open in new tab
+- [ ] Page handles 0 items in any category gracefully
+- [ ] Responsive layout
+
+---
+
+## SPEC-014: SEO and Social Sharing
+
+### Purpose
+Ensure the site is discoverable by search engines and renders correctly when shared on social media.
+
+### Requirements
+- Every page has: `<title>`, `<meta name="description">`, canonical URL
+- Every page has OG tags: `og:title`, `og:description`, `og:image`, `og:url`, `og:type`
+- Every page has Twitter Card tags: `twitter:card=summary_large_image`, `twitter:site`
+- `robots.txt` at site root allowing all crawlers
+- `sitemap.xml` auto-generated by Astro sitemap integration
+- Structured data (JSON-LD) for Organization on homepage:
+  - name, url, logo, description, sameAs (social URLs)
+
+### Acceptance Criteria
+- [ ] `robots.txt` is accessible at /robots.txt
+- [ ] `sitemap.xml` is accessible at /sitemap.xml and lists all pages
+- [ ] Google Rich Results Test passes for structured data on homepage
+- [ ] Sharing any page URL on Slack/Twitter/LinkedIn renders correct title, description, and image
+- [ ] No duplicate `<title>` or `<meta description>` across pages
+- [ ] Lighthouse SEO score >= 90 on all pages
+
+---
+
+## SPEC-015: Performance
+
+### Purpose
+Ensure fast load times, especially for users in bandwidth-constrained regions.
+
+### Requirements
+- Bundle CSS and JS (Astro handles this by default)
+- Optimize images: WebP format, responsive `srcset`, lazy loading
+- Self-host fonts (eliminate Google Fonts CDN request)
+- Minimize third-party scripts (analytics only)
+- Preload critical assets (fonts, hero image)
+- No render-blocking resources in `<head>`
+
+### Acceptance Criteria
+- [ ] Lighthouse Performance score >= 85 on all pages (target: >= 90)
+- [ ] Largest Contentful Paint (LCP) < 2.5s on simulated fast 3G
+- [ ] Cumulative Layout Shift (CLS) < 0.1
+- [ ] First Input Delay (FID) < 100ms
+- [ ] Total transfer size < 500KB for homepage (excluding cached assets)
+- [ ] All images served in WebP format with appropriate fallbacks
+- [ ] No unused CSS in production build (Tailwind purge)
+
+---
+
+## SPEC-016: Accessibility
+
+### Purpose
+Ensure the site is usable by people with disabilities and meets accessibility standards.
+
+### Requirements
+- Target: WCAG 2.1 AA compliance (confirm with client, Q3.4)
+- Semantic HTML: proper heading hierarchy, landmarks (`<nav>`, `<main>`, `<footer>`, `<article>`, `<section>`)
+- All images have descriptive alt text
+- Color contrast ratio >= 4.5:1 for normal text, >= 3:1 for large text
+- Focus indicators visible on all interactive elements
+- Skip-to-content link
+- Form labels associated with inputs
+- ARIA attributes where semantic HTML is insufficient
+
+### Acceptance Criteria
+- [ ] Lighthouse Accessibility score >= 90 on all pages
+- [ ] axe-core automated scan: 0 critical/serious violations
+- [ ] Keyboard-only navigation: all interactive elements reachable and operable
+- [ ] Screen reader testing: NVDA or VoiceOver can navigate all content
+- [ ] Focus is never trapped (except in modal dialogs, which must have Escape to close)
+- [ ] Color is not the only means of conveying information (e.g., error states use icon + text, not just red color)
+- [ ] Text can be zoomed to 200% without loss of content or functionality
+
+---
+
+## SPEC-017: 404 Page
+
+### Purpose
+Provide a helpful experience when a visitor reaches a non-existent URL.
+
+### Requirements
+- Friendly message: "Page not found"
+- Link back to homepage
+- Optionally: search box or suggested pages
+- Consistent layout (uses BaseLayout with nav and footer)
+
+### Acceptance Criteria
+- [ ] Returns HTTP 404 status code
+- [ ] Displays helpful message with link to homepage
+- [ ] Uses the site's standard layout (nav, footer, styling)
+- [ ] Does not display a blank page or browser default error
+
+---
+
+## Development Phases
+
+### Phase 1: Foundation (Priority: Must Have)
+
+| Spec | Description |
+|------|-------------|
+| SPEC-001 | Base Layout |
+| SPEC-002 | Navigation |
+| SPEC-003 | Footer |
+| SPEC-004 | Home Page |
+| SPEC-005 | About Overview |
+| SPEC-011 | Contact Page |
+| SPEC-014 | SEO |
+| SPEC-015 | Performance |
+| SPEC-016 | Accessibility |
+| SPEC-017 | 404 Page |
+
+### Phase 2: Content Pages (Priority: Should Have)
+
+| Spec | Description |
+|------|-------------|
+| SPEC-006 | Team Page |
+| SPEC-007 | Advisory Board |
+| SPEC-008 | Projects Page |
+| SPEC-009 | Individual Project Page |
+| SPEC-010 | News Page |
+
+### Phase 3: Enhanced Features (Priority: Could Have)
+
+| Spec | Description |
+|------|-------------|
+| SPEC-012 | Volunteer Page |
+| SPEC-013 | Resources Page |
+
+---
+
+## Revision History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 0.1.0 | Feb 2026 | Initial draft |
+
+---
+
+_This specification will be updated to version 1.0.0 once client questionnaire responses confirm the feature scope. Each spec will then be assigned to a developer and tracked through the build-review-approve cycle._


### PR DESCRIPTION
Add draft planning documentation for the sdgailab.org website revamp, including requirements, architecture decisions, wireframes, scaffold specs, content pipeline, and detailed acceptance criteria.

Also add an editor guide for the planned Supabase-backed admin panel.