### PR TITLE
fix: complete admin magic-link sign-in and clarify login errors

### DIFF
--- a/src/islands/admin/AdminApp.test.tsx
+++ b/src/islands/admin/AdminApp.test.tsx
@@ -33,6 +33,10 @@ vi.mock('./auth/LoginPage', () => ({
   default: () => <div data-testid="login-page">Login</div>,
 }));
 
+vi.mock('./auth/AuthCallback', () => ({
+  default: () => <div data-testid="auth-callback">Signing you in...</div>,
+}));
+
 vi.mock('./layout/AdminLayout', () => ({
   default: ({
     children,
@@ -82,6 +86,7 @@ describe('AdminApp', () => {
     authState.isEditor = false;
     authState.loading = false;
     authState.authorizationError = null;
+    window.history.replaceState({}, '', '/');
     window.location.hash = '#/';
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -153,15 +158,13 @@ describe('AdminApp', () => {
     expect(container.querySelector('[data-testid="projects-list-page"]')).not.toBeNull();
   });
 
-  it('shows a signing-in message when auth tokens are present in the hash', async () => {
-    authState.session = { user: { email: 'editor@example.org' } };
-    authState.isEditor = true;
-    window.location.hash = '#access_token=test-token';
+  it('renders the auth callback when magic-link params are present', async () => {
+    window.history.replaceState({}, '', '/admin?code=test-code');
 
     await renderApp();
 
-    expect(container.textContent).toContain('Signing you in...');
-    expect(container.querySelector('[data-testid="admin-layout"]')).toBeNull();
+    expect(container.querySelector('[data-testid="auth-callback"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="login-page"]')).toBeNull();
   });
 
   it('signs out from the unauthorized page', async () => {

--- a/src/islands/admin/AdminApp.tsx
+++ b/src/islands/admin/AdminApp.tsx
@@ -7,6 +7,8 @@ import {
   useRef,
   useState,
 } from 'react';
+import { hasAuthCallbackParams } from '../../lib/auth-callback';
+import AuthCallback from './auth/AuthCallback';
 import { AuthProvider, useAuth } from './auth/AuthProvider';
 import LoginPage from './auth/LoginPage';
 import AdminLayout from './layout/AdminLayout';
@@ -184,7 +186,11 @@ function matchRoute(path: string, id: string | null): React.ReactNode {
 function AdminAppInner() {
   const { session, isEditor, loading } = useAuth();
   const { path, id } = useHashRoute();
-  const hash = typeof window !== 'undefined' ? window.location.hash : '';
+  const authCallback = typeof window !== 'undefined' && hasAuthCallbackParams();
+
+  if (authCallback) {
+    return <AuthCallback />;
+  }
 
   if (loading) {
     return (
@@ -193,14 +199,6 @@ function AdminAppInner() {
           className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent"
           aria-label="Loading"
         />
-      </div>
-    );
-  }
-
-  if (hash.includes('access_token')) {
-    return (
-      <div className="flex min-h-screen items-center justify-center text-gray-600">
-        Signing you in...
       </div>
     );
   }

--- a/src/islands/admin/admin-shell.unit.test.tsx
+++ b/src/islands/admin/admin-shell.unit.test.tsx
@@ -4,10 +4,12 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { signInWithOtpMock, getSessionMock, onAuthStateChangeMock } = vi.hoisted(() => ({
+const { signInWithOtpMock, getSessionMock, onAuthStateChangeMock, setSessionMock, exchangeCodeForSessionMock } = vi.hoisted(() => ({
   signInWithOtpMock: vi.fn(),
   getSessionMock: vi.fn(),
   onAuthStateChangeMock: vi.fn(),
+  setSessionMock: vi.fn().mockResolvedValue({ error: null }),
+  exchangeCodeForSessionMock: vi.fn().mockResolvedValue({ error: null }),
 }));
 
 vi.mock('../../lib/supabase-auth', () => ({
@@ -17,6 +19,8 @@ vi.mock('../../lib/supabase-auth', () => ({
       onAuthStateChange: onAuthStateChangeMock,
       signInWithOtp: signInWithOtpMock,
       signOut: vi.fn(),
+      setSession: setSessionMock,
+      exchangeCodeForSession: exchangeCodeForSessionMock,
     },
   }),
 }));
@@ -92,7 +96,7 @@ describe('admin shell (unit)', () => {
   });
 
   it('AuthCallback renders the signing-in state for token hashes', async () => {
-    window.location.hash = '#access_token=test-token&type=magiclink';
+    window.location.hash = '#access_token=test-token&refresh_token=refresh&type=magiclink';
     await render(
       <AuthProvider>
         <AuthCallback />

--- a/src/islands/admin/auth/AuthCallback.integration.test.tsx
+++ b/src/islands/admin/auth/AuthCallback.integration.test.tsx
@@ -15,6 +15,8 @@ const {
   getSessionMock,
   onAuthStateChangeMock,
   subscriptionUnsubscribeMock,
+  setSessionMock,
+  exchangeCodeForSessionMock,
 } = vi.hoisted(() => ({
   getAuthorizedAdminMock: vi.fn(),
   clearAuthorizedAdminCacheMock: vi.fn(),
@@ -23,6 +25,8 @@ const {
   getSessionMock: vi.fn(),
   onAuthStateChangeMock: vi.fn(),
   subscriptionUnsubscribeMock: vi.fn(),
+  setSessionMock: vi.fn().mockResolvedValue({ error: null }),
+  exchangeCodeForSessionMock: vi.fn().mockResolvedValue({ error: null }),
 }));
 
 let authStateChangeCallback: AuthCallback | null = null;
@@ -39,6 +43,8 @@ vi.mock('../../../lib/supabase-auth', () => ({
       signOut: signOutMock,
       getSession: getSessionMock,
       onAuthStateChange: onAuthStateChangeMock,
+      setSession: setSessionMock,
+      exchangeCodeForSession: exchangeCodeForSessionMock,
     },
   }),
 }));
@@ -64,8 +70,8 @@ describe('AuthCallback (integration)', () => {
       return { data: { subscription: { unsubscribe: subscriptionUnsubscribeMock } } };
     });
     getAuthorizedAdminMock.mockResolvedValue({
-      data: { email: 'editor@example.org', role: 'editor' },
-      error: null,
+      email: 'editor@example.org',
+      role: 'editor',
     });
 
     window.location.hash = '#access_token=test-token&refresh_token=refresh&type=magiclink';
@@ -96,6 +102,10 @@ describe('AuthCallback (integration)', () => {
   it('redirects to the dashboard when AuthProvider establishes a session', async () => {
     await renderCallback();
     expect(container.textContent).toContain('Signing you in...');
+    expect(setSessionMock).toHaveBeenCalledWith({
+      access_token: 'test-token',
+      refresh_token: 'refresh',
+    });
 
     await act(async () => {
       authStateChangeCallback?.('SIGNED_IN', {

--- a/src/islands/admin/auth/AuthCallback.test.tsx
+++ b/src/islands/admin/auth/AuthCallback.test.tsx
@@ -9,8 +9,19 @@ const authState = vi.hoisted(() => ({
   loading: true,
 }));
 
+const { completeAuthCallbackMock, hasAuthCallbackParamsMock } = vi.hoisted(() => ({
+  completeAuthCallbackMock: vi.fn(),
+  hasAuthCallbackParamsMock: vi.fn(),
+}));
+
 vi.mock('./AuthProvider', () => ({
   useAuth: () => authState,
+}));
+
+vi.mock('../../../lib/auth-callback', () => ({
+  hasAuthCallbackParams: hasAuthCallbackParamsMock,
+  completeAuthCallback: completeAuthCallbackMock,
+  clearAuthCallbackQueryParams: vi.fn(),
 }));
 
 import AuthCallback from './AuthCallback';
@@ -21,9 +32,10 @@ describe('AuthCallback', () => {
 
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true;
-    vi.useFakeTimers();
     authState.session = null;
     authState.loading = true;
+    hasAuthCallbackParamsMock.mockReturnValue(true);
+    completeAuthCallbackMock.mockResolvedValue({ error: null });
     window.location.hash = '';
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -35,7 +47,6 @@ describe('AuthCallback', () => {
       root.unmount();
     });
     container.remove();
-    vi.useRealTimers();
   });
 
   async function renderCallback() {
@@ -44,11 +55,12 @@ describe('AuthCallback', () => {
     });
     await act(async () => {
       await Promise.resolve();
+      await Promise.resolve();
     });
   }
 
-  it('shows an error when the callback hash has no auth tokens', async () => {
-    window.location.hash = '#/login';
+  it('shows an error when the callback has no auth params', async () => {
+    hasAuthCallbackParamsMock.mockReturnValue(false);
     await renderCallback();
 
     expect(container.textContent).toContain('Invalid or expired link');
@@ -56,15 +68,14 @@ describe('AuthCallback', () => {
   });
 
   it('shows a loading state while auth tokens are being processed', async () => {
-    window.location.hash = '#access_token=test-token&type=magiclink';
     await renderCallback();
 
     expect(container.textContent).toContain('Signing you in...');
     expect(container.querySelector('.animate-spin')).not.toBeNull();
+    expect(completeAuthCallbackMock).toHaveBeenCalled();
   });
 
   it('redirects to the dashboard when a session becomes available', async () => {
-    window.location.hash = '#access_token=test-token&refresh_token=refresh';
     await renderCallback();
 
     authState.session = { user: { email: 'editor@example.org' } };
@@ -78,21 +89,13 @@ describe('AuthCallback', () => {
     expect(window.location.hash).toBe('#/');
   });
 
-  it('redirects after a timeout when loading completes without a session', async () => {
-    window.location.hash = '#access_token=test-token';
+  it('shows an error when callback exchange fails', async () => {
+    completeAuthCallbackMock.mockResolvedValue({
+      error: new Error('Invalid grant'),
+    });
+
     await renderCallback();
 
-    authState.loading = false;
-
-    await act(async () => {
-      root.render(<AuthCallback />);
-      await Promise.resolve();
-    });
-
-    await act(async () => {
-      vi.advanceTimersByTime(1500);
-    });
-
-    expect(window.location.hash).toBe('#/');
+    expect(container.textContent).toContain('Invalid or expired link');
   });
 });

--- a/src/islands/admin/auth/AuthCallback.tsx
+++ b/src/islands/admin/auth/AuthCallback.tsx
@@ -1,28 +1,43 @@
 import { useEffect, useState } from 'react';
+import {
+  clearAuthCallbackQueryParams,
+  completeAuthCallback,
+  hasAuthCallbackParams,
+} from '../../../lib/auth-callback';
 import { useAuth } from './AuthProvider';
-
-function hasAuthTokens(): boolean {
-  const hash = window.location.hash;
-  if (!hash) return false;
-  const params = new URLSearchParams(hash.substring(1));
-  return (
-    params.has('access_token') ||
-    params.has('refresh_token') ||
-    params.get('type') === 'magiclink' ||
-    params.get('type') === 'recovery'
-  );
-}
 
 export default function AuthCallback() {
   const { session, loading } = useAuth();
   const [error, setError] = useState(false);
+  const [processing, setProcessing] = useState(true);
 
   useEffect(() => {
-    const tokensPresent = hasAuthTokens();
-    if (!tokensPresent) {
-      setError(true);
-      return;
+    let cancelled = false;
+
+    async function handleCallback() {
+      if (!hasAuthCallbackParams()) {
+        if (!cancelled) {
+          setError(true);
+          setProcessing(false);
+        }
+        return;
+      }
+
+      const { error: exchangeError } = await completeAuthCallback();
+      if (!cancelled) {
+        if (exchangeError) {
+          setError(true);
+        }
+        clearAuthCallbackQueryParams();
+        setProcessing(false);
+      }
     }
+
+    void handleCallback();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -30,17 +45,6 @@ export default function AuthCallback() {
       window.location.hash = '#/';
     }
   }, [session, error]);
-
-  useEffect(() => {
-    if (error) return;
-    const tokensPresent = hasAuthTokens();
-    if (tokensPresent && !loading) {
-      const t = setTimeout(() => {
-        window.location.hash = '#/';
-      }, 1500);
-      return () => clearTimeout(t);
-    }
-  }, [loading, error]);
 
   if (error) {
     return (
@@ -58,10 +62,14 @@ export default function AuthCallback() {
     );
   }
 
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 px-4">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary-200 border-t-primary" />
-      <p className="text-gray-600">Signing you in...</p>
-    </div>
-  );
+  if (processing || loading || !session) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 px-4">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary-200 border-t-primary" />
+        <p className="text-gray-600">Signing you in...</p>
+      </div>
+    );
+  }
+
+  return null;
 }

--- a/src/islands/admin/auth/AuthProvider.test.tsx
+++ b/src/islands/admin/auth/AuthProvider.test.tsx
@@ -210,6 +210,37 @@ describe('AuthProvider', () => {
     expect(node?.getAttribute('data-error')).toBe('');
   });
 
+  it('applies sessions delivered via INITIAL_SESSION', async () => {
+    getSessionMock.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+    getAuthorizedAdminMock.mockResolvedValue({
+      email: 'editor@example.org',
+      role: 'editor',
+    });
+
+    await act(async () => {
+      root.render(
+        <AuthProvider>
+          <Harness />
+        </AuthProvider>
+      );
+    });
+    await flushEffects();
+
+    await act(async () => {
+      authStateChangeCallback?.('INITIAL_SESSION', {
+        user: { email: 'editor@example.org' },
+      });
+    });
+    await flushEffects();
+
+    const node = container.querySelector('[data-testid="auth-state"]');
+    expect(node?.getAttribute('data-is-editor')).toBe('true');
+    expect(node?.getAttribute('data-user-email')).toBe('editor@example.org');
+  });
+
   it('responds to auth state changes and tears down the subscription', async () => {
     await act(async () => {
       root.render(

--- a/src/islands/admin/auth/AuthProvider.tsx
+++ b/src/islands/admin/auth/AuthProvider.tsx
@@ -80,6 +80,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     });
 
     const { data: { subscription } } = getSupabaseAuth().auth.onAuthStateChange((event, s) => {
+      if (event === 'INITIAL_SESSION') {
+        void applySession(s);
+        return;
+      }
       if (event === 'SIGNED_IN' && s) {
         setLoading(true);
         void applySession(s);

--- a/src/islands/admin/auth/LoginPage.test.tsx
+++ b/src/islands/admin/auth/LoginPage.test.tsx
@@ -126,9 +126,9 @@ describe('LoginPage', () => {
     expect(container.textContent).toContain('Too many sign-in requests for this email address.');
   });
 
-  it('shows the non-allowlisted guidance when Supabase rejects the OTP request', async () => {
+  it('shows rate-limit guidance when Supabase throttles email sending', async () => {
     signInWithOtpMock.mockResolvedValue({
-      error: { message: 'User not allowed' },
+      error: { code: 'over_email_send_rate_limit', message: 'email rate limit exceeded' },
     });
 
     await act(async () => {
@@ -147,9 +147,32 @@ describe('LoginPage', () => {
     });
     await flushEffects();
 
-    expect(container.textContent).toContain(
-      'This email is not set up for editor access yet. Please contact the SDG AI Lab site administrator.'
-    );
+    expect(container.textContent).toContain('hourly email limit');
+  });
+
+  it('explains when Supabase Auth has no account for the email', async () => {
+    signInWithOtpMock.mockResolvedValue({
+      error: { code: 'signup_disabled', message: 'Signups not allowed for otp' },
+    });
+
+    await act(async () => {
+      root.render(<LoginPage />);
+    });
+
+    const input = container.querySelector('input[type="email"]') as HTMLInputElement;
+    const form = container.querySelector('form') as HTMLFormElement;
+
+    await act(async () => {
+      setInputValue(input, 'editor@example.org');
+    });
+
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+    await flushEffects();
+
+    expect(container.textContent).toContain('Supabase Auth account');
+    expect(container.textContent).not.toContain('not set up for editor access');
   });
 
   it('has no detectable accessibility violations', async () => {

--- a/src/islands/admin/auth/LoginPage.tsx
+++ b/src/islands/admin/auth/LoginPage.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { consumeRateLimit, normalizeAdminEmail } from '../../../lib/admin-security';
+import { getMagicLinkRequestError } from '../../../lib/magic-link-errors';
 import { getSupabaseAuth } from '../../../lib/supabase-auth';
 
-export default function LoginPage() {
-  const [email, setEmail] = useState('');
+export default function LoginPage() {  const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -38,9 +38,7 @@ export default function LoginPage() {
         },
       });
       if (signInError) {
-        setError(
-          'This email is not set up for editor access yet. Please contact the SDG AI Lab site administrator.'
-        );
+        setError(getMagicLinkRequestError(signInError));
         return;
       }
       setSubmitted(true);

--- a/src/lib/auth-callback.test.ts
+++ b/src/lib/auth-callback.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { setSessionMock, exchangeCodeForSessionMock } = vi.hoisted(() => ({
+  setSessionMock: vi.fn(),
+  exchangeCodeForSessionMock: vi.fn(),
+}));
+
+vi.mock('./supabase-auth', () => ({
+  getSupabaseAuth: () => ({
+    auth: {
+      setSession: setSessionMock,
+      exchangeCodeForSession: exchangeCodeForSessionMock,
+    },
+  }),
+}));
+
+import {
+  clearAuthCallbackQueryParams,
+  completeAuthCallback,
+  hasAuthCallbackParams,
+} from './auth-callback';
+
+describe('auth-callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setSessionMock.mockResolvedValue({ error: null });
+    exchangeCodeForSessionMock.mockResolvedValue({ error: null });
+    window.history.replaceState({}, '', '/admin');
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+    window.location.hash = '';
+  });
+
+  it('detects hash-based magic link tokens', () => {
+    window.location.hash = '#access_token=abc&refresh_token=def&type=magiclink';
+    expect(hasAuthCallbackParams()).toBe(true);
+  });
+
+  it('detects PKCE code query parameters', () => {
+    window.history.replaceState({}, '', '/admin?code=pkce-code');
+    expect(hasAuthCallbackParams()).toBe(true);
+  });
+
+  it('exchanges hash tokens via setSession', async () => {
+    window.location.hash = '#access_token=abc&refresh_token=def&type=magiclink';
+
+    const result = await completeAuthCallback();
+
+    expect(result.error).toBeNull();
+    expect(setSessionMock).toHaveBeenCalledWith({
+      access_token: 'abc',
+      refresh_token: 'def',
+    });
+  });
+
+  it('exchanges PKCE codes via exchangeCodeForSession', async () => {
+    window.history.replaceState({}, '', '/admin?code=pkce-code');
+
+    const result = await completeAuthCallback();
+
+    expect(result.error).toBeNull();
+    expect(exchangeCodeForSessionMock).toHaveBeenCalledWith('pkce-code');
+  });
+
+  it('returns an error when no callback params are present', async () => {
+    const result = await completeAuthCallback();
+    expect(result.error?.message).toBe('No auth callback parameters found');
+  });
+
+  it('clears callback query params from the URL', () => {
+    window.history.replaceState({}, '', '/admin?code=pkce-code&error=fail');
+    window.location.hash = '#/';
+
+    clearAuthCallbackQueryParams();
+
+    expect(window.location.pathname).toBe('/admin');
+    expect(window.location.search).toBe('');
+    expect(window.location.hash).toBe('#/');
+  });
+});

--- a/src/lib/auth-callback.ts
+++ b/src/lib/auth-callback.ts
@@ -1,0 +1,54 @@
+import { getSupabaseAuth } from './supabase-auth';
+
+/** True when the current URL carries Supabase magic-link / OAuth callback parameters. */
+export function hasAuthCallbackParams(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  const hash = window.location.hash;
+  if (
+    hash.includes('access_token') ||
+    hash.includes('refresh_token') ||
+    hash.includes('type=magiclink') ||
+    hash.includes('type=recovery')
+  ) {
+    return true;
+  }
+
+  return new URLSearchParams(window.location.search).has('code');
+}
+
+/** Exchange hash or PKCE query callback params for a Supabase session. */
+export async function completeAuthCallback(): Promise<{ error: Error | null }> {
+  const auth = getSupabaseAuth().auth;
+
+  const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''));
+  const accessToken = hashParams.get('access_token');
+  const refreshToken = hashParams.get('refresh_token');
+
+  if (accessToken && refreshToken) {
+    const { error } = await auth.setSession({
+      access_token: accessToken,
+      refresh_token: refreshToken,
+    });
+    return { error: error ?? null };
+  }
+
+  const searchParams = new URLSearchParams(window.location.search);
+  const code = searchParams.get('code');
+  if (code) {
+    const { error } = await auth.exchangeCodeForSession(code);
+    return { error: error ?? null };
+  }
+
+  return { error: new Error('No auth callback parameters found') };
+}
+
+/** Remove callback query params so refresh does not re-process the code. */
+export function clearAuthCallbackQueryParams(): void {
+  const url = new URL(window.location.href);
+  url.searchParams.delete('code');
+  url.searchParams.delete('error');
+  url.searchParams.delete('error_description');
+  const next = `${url.pathname}${url.search}${url.hash}`;
+  window.history.replaceState({}, '', next);
+}

--- a/src/lib/magic-link-errors.test.ts
+++ b/src/lib/magic-link-errors.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { getMagicLinkRequestError } from './magic-link-errors';
+
+describe('getMagicLinkRequestError', () => {
+  it('explains email rate limits without blaming editor access', () => {
+    expect(
+      getMagicLinkRequestError({
+        code: 'over_email_send_rate_limit',
+        message: 'email rate limit exceeded',
+      })
+    ).toContain('hourly email limit');
+  });
+
+  it('explains missing Supabase Auth accounts separately from CMS allowlist', () => {
+    expect(
+      getMagicLinkRequestError({
+        code: 'signup_disabled',
+        message: 'Signups not allowed for otp',
+      })
+    ).toContain('Supabase Auth account');
+  });
+
+  it('explains redirect URL misconfiguration', () => {
+    expect(
+      getMagicLinkRequestError({
+        message: 'Invalid redirect URL',
+      })
+    ).toContain('redirect settings');
+  });
+
+  it('uses a neutral fallback for unknown errors', () => {
+    const message = getMagicLinkRequestError({
+      code: 'unexpected_error',
+      message: 'something went wrong',
+    });
+    expect(message).toContain('could not send a magic link');
+    expect(message).not.toContain('not set up for editor access');
+  });
+});

--- a/src/lib/magic-link-errors.ts
+++ b/src/lib/magic-link-errors.ts
@@ -1,0 +1,41 @@
+export interface MagicLinkSignInError {
+  code?: string;
+  message?: string;
+}
+
+/**
+ * Maps Supabase magic-link request failures to user-facing copy.
+ * Avoid blaming editor access unless the email truly cannot sign in.
+ */
+export function getMagicLinkRequestError(error: MagicLinkSignInError): string {
+  const code = error.code?.toLowerCase() ?? '';
+  const message = error.message?.toLowerCase() ?? '';
+
+  if (
+    code === 'over_email_send_rate_limit' ||
+    code === 'over_request_rate_limit' ||
+    message.includes('rate limit')
+  ) {
+    return 'This project has reached Supabase’s hourly email limit (shared across all addresses). Wait up to an hour, use a magic link from an earlier email if you have one, or ask an administrator to configure custom SMTP for higher limits.';
+  }
+
+  if (
+    code === 'signup_disabled' ||
+    message.includes('signups not allowed') ||
+    message.includes('user not found') ||
+    message.includes('not authorized') ||
+    code === 'otp_disabled'
+  ) {
+    return 'This email does not have a Supabase Auth account for CMS login. Ask the site administrator to invite you in Supabase Auth and confirm your email is on the editor allowlist.';
+  }
+
+  if (message.includes('redirect') || message.includes('redirect_to')) {
+    return 'This site is not configured to accept logins from this URL. Contact the site administrator to add the admin URL to Supabase redirect settings.';
+  }
+
+  if (code === 'validation_failed' || message.includes('invalid email')) {
+    return 'Enter a valid email address and try again.';
+  }
+
+  return 'We could not send a magic link right now. Please try again in a few minutes or contact the SDG AI Lab site administrator if the problem continues.';
+}

--- a/src/lib/supabase-auth.test.ts
+++ b/src/lib/supabase-auth.test.ts
@@ -41,6 +41,7 @@ describe('getSupabaseAuth', () => {
       auth: {
         autoRefreshToken: true,
         persistSession: true,
+        detectSessionInUrl: true,
       },
     });
     expect(first).toBe(second);

--- a/src/lib/supabase-auth.ts
+++ b/src/lib/supabase-auth.ts
@@ -24,6 +24,7 @@ export function getSupabaseAuth(): SupabaseClient {
       auth: {
         autoRefreshToken: true,
         persistSession: true,
+        detectSessionInUrl: true,
       },
     });
   }

--- a/src/pages/admin.astro
+++ b/src/pages/admin.astro
@@ -12,7 +12,7 @@ const adminContentSecurityPolicy = [
   "font-src 'self' data:",
   "script-src 'self' 'unsafe-inline'",
   "style-src 'self' 'unsafe-inline'",
-  "connect-src 'self' https://*.supabase.co",
+  "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
   "frame-src 'none'",
   "manifest-src 'self'",
   'upgrade-insecure-requests',


### PR DESCRIPTION
Wire AuthCallback for hash and PKCE redirects, handle INITIAL_SESSION in AuthProvider, and map Supabase OTP failures to accurate messages instead of the misleading editor-access error.