### PR TITLE
feat: give projects more prominence on /projects and home

### DIFF
--- a/src/islands/FeaturedProjects.tsx
+++ b/src/islands/FeaturedProjects.tsx
@@ -1,44 +1,133 @@
-import { useEffect, useState } from 'react';
-import { getFeaturedProjects } from '../lib/queries';
+import { useEffect, useRef, useState } from 'react';
+import { getFeaturedProjects, getPublishedProjects } from '../lib/queries';
 import type { FeaturedProjectCard } from '../lib/types';
-import ProjectCard from './components/ProjectCard';
+import { ProjectOverlayCard } from './components/ProjectShowcase';
 
-interface FeaturedProjectsProps {
-  limit?: number;
+function mergeProjects(featured: FeaturedProjectCard[], published: FeaturedProjectCard[]) {
+  const byId = new Map<string, FeaturedProjectCard>();
+  [...featured, ...published].forEach((project) => {
+    if (!byId.has(project.id)) byId.set(project.id, project);
+  });
+  return [...byId.values()];
 }
 
-export default function FeaturedProjects({ limit }: FeaturedProjectsProps) {
+function fillRow(projects: FeaturedProjectCard[], count: number, offset: number) {
+  if (projects.length === 0) return [];
+  return Array.from({ length: count }, (_, index) => projects[(index + offset) % projects.length]);
+}
+
+export default function FeaturedProjects() {
   const [projects, setProjects] = useState<FeaturedProjectCard[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const stageRef = useRef<HTMLDivElement>(null);
+  const topRowRef = useRef<HTMLDivElement>(null);
+  const bottomRowRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    getFeaturedProjects().then(({ data, error: err }) => {
-      if (err) setError(err);
-      setProjects(data);
+    Promise.all([getFeaturedProjects(), getPublishedProjects()]).then(([featured, published]) => {
+      if (featured.error && published.data.length === 0) setError(featured.error);
+      setProjects(mergeProjects(featured.data, published.data));
       setLoading(false);
     });
   }, []);
 
+  useEffect(() => {
+    const stage = stageRef.current;
+    const topRow = topRowRef.current;
+    const bottomRow = bottomRowRef.current;
+    if (!stage || !topRow || !bottomRow || projects.length === 0) return;
+
+    const reduceMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    if (reduceMotion || !window.matchMedia) return;
+
+    let frame = 0;
+
+    const update = () => {
+      const rect = stage.getBoundingClientRect();
+      const viewHeight = window.innerHeight;
+      const start = viewHeight * 0.9;
+      const end = -rect.height + viewHeight * 0.2;
+      const progress = Math.min(1, Math.max(0, (start - rect.top) / (start - end || 1)));
+      const shift = progress * 18;
+      topRow.style.transform = `translate3d(${6 - shift}%, 0, 0)`;
+      bottomRow.style.transform = `translate3d(${-10 + shift}%, 0, 0)`;
+    };
+
+    const onScroll = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        update();
+      });
+    };
+
+    update();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+      if (frame) window.cancelAnimationFrame(frame);
+    };
+  }, [projects]);
+
   if (loading) {
-    return <div className="h-40 rounded-xl border border-lab-border bg-lab-section" role="status" aria-label="Loading featured projects" />;
+    return (
+      <div className="project-scroll-stage" role="status" aria-label="Loading featured projects">
+        <div className="project-scroll-row">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="project-scroll-card project-scroll-card--skeleton" />
+          ))}
+        </div>
+      </div>
+    );
   }
 
-  return (
-    <div>
-      {error && projects.length === 0 && <p className="mb-5 rounded-lg bg-amber-50 p-4 text-sm text-amber-900">Featured projects are currently being updated.</p>}
-      {projects.length === 0 ? (
+  if (projects.length === 0) {
+    return (
+      <div className="mx-auto w-[min(100%-2rem,1120px)]">
+        {error && (
+          <p className="mb-5 rounded-lg bg-amber-50 p-4 text-sm text-amber-900">
+            Featured projects are currently being updated.
+          </p>
+        )}
         <div className="rounded-2xl border border-dashed border-lab-border bg-lab-section p-8 text-center">
           <h3 className="text-lg font-bold text-lab-text">Featured projects are being updated.</h3>
           <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-lab-muted">
             Explore the full portfolio to browse published project work.
           </p>
         </div>
-      ) : (
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {(limit ? projects.slice(0, limit) : projects).map((project) => <ProjectCard key={project.id} project={project} />)}
-        </div>
-      )}
+      </div>
+    );
+  }
+
+  const cardsPerRow = Math.max(6, Math.min(8, projects.length + 2));
+  const topRow = fillRow(projects, cardsPerRow, 0);
+  const bottomRow = fillRow(projects, cardsPerRow, Math.ceil(projects.length / 2));
+
+  return (
+    <div ref={stageRef} className="project-scroll-stage" aria-label="Featured projects">
+      <div ref={topRowRef} className="project-scroll-row">
+        {topRow.map((project, index) => (
+          <ProjectOverlayCard
+            key={`${project.id}-top-${index}`}
+            project={project}
+            index={index}
+            className={`project-scroll-card ${index % 2 === 0 ? 'project-scroll-card--wide' : ''}`}
+          />
+        ))}
+      </div>
+      <div ref={bottomRowRef} className="project-scroll-row project-scroll-row--bottom">
+        {bottomRow.map((project, index) => (
+          <ProjectOverlayCard
+            key={`${project.id}-bottom-${index}`}
+            project={project}
+            index={index + cardsPerRow}
+            className={`project-scroll-card ${index % 2 === 1 ? 'project-scroll-card--wide' : ''}`}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/islands/LatestActivity.tsx
+++ b/src/islands/LatestActivity.tsx
@@ -4,7 +4,6 @@ import type { NewsListItem } from '../lib/types';
 import { withBase } from '../lib/url';
 
 const discoveryLinks = [
-  { label: 'Projects', href: '/projects', description: 'Lorem ipsum dolor sit amet.' },
   { label: 'Publications', href: '/resources', description: 'Lorem ipsum dolor sit amet.' },
   { label: 'News', href: '/news', description: 'Lorem ipsum dolor sit amet.' },
 ];
@@ -31,7 +30,7 @@ export default function LatestActivity() {
   return (
     <div className="grid gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-start">
       <div>
-        <div className="grid gap-4 sm:grid-cols-3" aria-label="Content discovery routes">
+        <div className="grid gap-4 sm:grid-cols-2" aria-label="Content discovery routes">
           {discoveryLinks.map((link) => (
             <a
               key={link.href}

--- a/src/islands/ProjectList.tsx
+++ b/src/islands/ProjectList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { getPublishedProjects } from '../lib/queries';
 import type { ProjectListItem } from '../lib/types';
 import ProjectCard from './components/ProjectCard';
+import ProjectShowcase from './components/ProjectShowcase';
 import { impactAreas } from '../data/sampleContent';
 
 const ALL_AREAS = 'all';
@@ -9,6 +10,7 @@ const ALL_YEARS = 'all';
 const ALL_COUNTRIES = 'all';
 const ALL_TECHNOLOGIES = 'all';
 type SortOrder = 'newest' | 'oldest' | 'default';
+type ViewMode = 'gallery' | 'cards';
 
 function getProjectYear(project: ProjectListItem) {
   return typeof project.project_year === 'number' ? project.project_year : null;
@@ -50,6 +52,7 @@ export default function ProjectList() {
   const [activeCountry, setActiveCountry] = useState<string>(ALL_COUNTRIES);
   const [activeTechnology, setActiveTechnology] = useState<string>(ALL_TECHNOLOGIES);
   const [sortOrder, setSortOrder] = useState<SortOrder>('newest');
+  const [viewMode, setViewMode] = useState<ViewMode>('gallery');
   const [searchQuery, setSearchQuery] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -122,10 +125,10 @@ export default function ProjectList() {
 
   return (
     <div>
-      {error && <p className="mb-5 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm font-semibold text-amber-900">Project information is currently being updated.</p>}
+      {error && <p className="mx-auto mb-5 w-[min(100%-2rem,1120px)] rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm font-semibold text-amber-900">Project information is currently being updated.</p>}
 
 
-      <div className="mb-8 rounded-3xl bg-lab-section/70 p-4 ring-1 ring-lab-border/70 sm:p-5">
+      <div className="mx-auto mb-8 w-[min(100%-2rem,1120px)] rounded-3xl bg-lab-section/70 p-4 ring-1 ring-lab-border/70 sm:p-5">
         <div className="grid gap-4 xl:grid-cols-[1.2fr_2fr] xl:items-end">
           <label className="block text-xs font-black uppercase tracking-[0.16em] text-lab-accent-soft">
             Search projects
@@ -206,15 +209,39 @@ export default function ProjectList() {
           <p className="text-sm font-bold text-lab-muted" aria-live="polite">
             Showing {filteredProjects.length} of {projects.length} projects
           </p>
-          {hasActiveFilters && (
-            <button
-              type="button"
-              onClick={resetFilters}
-              className="text-sm font-black text-lab-accent-soft transition hover:text-primary-light"
-            >
-              Reset filters
-            </button>
-          )}
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="flex rounded-full border border-lab-border bg-lab-surface p-1" role="group" aria-label="Project layout">
+              <button
+                type="button"
+                onClick={() => setViewMode('gallery')}
+                aria-pressed={viewMode === 'gallery'}
+                className={`rounded-full px-4 py-2 text-sm font-bold transition ${
+                  viewMode === 'gallery' ? 'bg-lab-accent text-white shadow' : 'text-lab-muted hover:text-lab-accent-soft'
+                }`}
+              >
+                Gallery
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode('cards')}
+                aria-pressed={viewMode === 'cards'}
+                className={`rounded-full px-4 py-2 text-sm font-bold transition ${
+                  viewMode === 'cards' ? 'bg-lab-accent text-white shadow' : 'text-lab-muted hover:text-lab-accent-soft'
+                }`}
+              >
+                Cards
+              </button>
+            </div>
+            {hasActiveFilters && (
+              <button
+                type="button"
+                onClick={resetFilters}
+                className="text-sm font-black text-lab-accent-soft transition hover:text-primary-light"
+              >
+                Reset filters
+              </button>
+            )}
+          </div>
         </div>
 
         <div className="mt-5 flex flex-wrap gap-2" role="group" aria-label="Project impact area filters">
@@ -253,14 +280,16 @@ export default function ProjectList() {
       </div>
 
       {filteredProjects.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-lab-border bg-lab-section p-8 text-center">
+        <div className="mx-auto w-[min(100%-2rem,1120px)] rounded-2xl border border-dashed border-lab-border bg-lab-section p-8 text-center">
           <h3 className="text-lg font-black text-lab-text">No published projects match these filters yet.</h3>
           <p className="mx-auto mt-2 max-w-xl text-sm font-semibold leading-6 text-lab-muted">
             Try another keyword, impact area, country, technology or year.
           </p>
         </div>
+      ) : viewMode === 'gallery' ? (
+        <ProjectShowcase projects={filteredProjects} />
       ) : (
-        <div className="grid grid-cols-1 gap-x-7 gap-y-9 md:grid-cols-2 lg:grid-cols-3">
+        <div className="mx-auto grid w-[min(100%-2rem,1120px)] grid-cols-1 gap-x-7 gap-y-9 md:grid-cols-2 lg:grid-cols-3">
           {filteredProjects.map((project) => <ProjectCard key={project.id} project={project} />)}
         </div>
       )}

--- a/src/islands/components/ProjectShowcase.tsx
+++ b/src/islands/components/ProjectShowcase.tsx
@@ -1,0 +1,95 @@
+import type { FeaturedProjectCard } from '../../lib/types';
+import { withBase } from '../../lib/url';
+
+const gallerySizes = ['xl', 'tall', 'compact', 'wide', 'mid', 'mid'] as const;
+
+function uniqueCompact(items?: string[]) {
+  return Array.from(new Set((items ?? []).map((item) => item.trim()).filter(Boolean)));
+}
+
+function isLoopableVideo(url?: string | null) {
+  return Boolean(url && /\.(mp4|webm|ogg)(\?|$)/i.test(url));
+}
+
+export function ProjectOverlayCard({
+  project,
+  index = 0,
+  size = 'compact',
+  showSummary = false,
+  allowVideo = false,
+  className = '',
+}: {
+  project: FeaturedProjectCard;
+  index?: number;
+  size?: string;
+  showSummary?: boolean;
+  allowVideo?: boolean;
+  className?: string;
+}) {
+  const countries = uniqueCompact(project.implementation_countries);
+  const meta = [project.impact_area, project.project_year, countries[0]].filter(Boolean).join(' · ');
+  const videoUrl = allowVideo && isLoopableVideo(project.video_url) ? project.video_url : null;
+
+  return (
+    <a
+      href={withBase(`/projects/detail/?slug=${project.slug}`)}
+      className={`project-showcase-card project-showcase-card--${size} group ${className}`.trim()}
+    >
+      {videoUrl ? (
+        <video
+          className="h-full w-full object-cover"
+          src={videoUrl}
+          autoPlay
+          muted
+          loop
+          playsInline
+          poster={project.image_url ?? undefined}
+          aria-hidden="true"
+        />
+      ) : project.image_url ? (
+        <img
+          src={project.image_url}
+          alt=""
+          className="h-full w-full object-cover transition duration-700 group-hover:scale-105"
+          loading={index < 4 ? 'eager' : 'lazy'}
+        />
+      ) : (
+        <div
+          className="h-full w-full bg-gradient-to-br from-primary-900 via-primary to-lab-elevated"
+          aria-hidden="true"
+        />
+      )}
+      <div className="project-showcase-card__overlay">
+        {meta ? (
+          <p className="text-[0.68rem] font-black uppercase tracking-[0.16em] text-lab-accent-soft">
+            {meta}
+          </p>
+        ) : null}
+        <h3 className="mt-2 max-w-xl text-[clamp(1.15rem,2vw,2.1rem)] font-black leading-[1.08] tracking-[-0.03em] text-lab-text">
+          {project.title}
+        </h3>
+        {showSummary && project.summary ? (
+          <p className="mt-2 max-w-lg text-sm font-semibold leading-6 text-lab-muted line-clamp-2">
+            {project.summary}
+          </p>
+        ) : null}
+      </div>
+    </a>
+  );
+}
+
+export default function ProjectShowcase({ projects }: { projects: FeaturedProjectCard[] }) {
+  return (
+    <div className="project-showcase-grid" aria-label="Projects">
+      {projects.map((project, index) => (
+        <ProjectOverlayCard
+          key={project.id}
+          project={project}
+          index={index}
+          size={gallerySizes[index % gallerySizes.length]}
+          showSummary
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/islands/public-islands.test.tsx
+++ b/src/islands/public-islands.test.tsx
@@ -122,11 +122,11 @@ describe('public islands', () => {
       ],
       error: null,
     });
+    getPublishedProjectsMock.mockResolvedValue({ data: [], error: null });
 
     await render(<FeaturedProjects />);
 
     expect(container.textContent).toContain('Forecasting Platform');
-    expect(container.textContent).toContain('Supports better planning.');
     expect(container.querySelector('a')?.getAttribute('href')).toContain(
       '/projects/detail/?slug=forecasting-platform'
     );

--- a/src/islands/public-islands.unit.test.tsx
+++ b/src/islands/public-islands.unit.test.tsx
@@ -75,7 +75,7 @@ describe('public islands (unit)', () => {
 
 
 
-  it('FeaturedProjects can limit homepage selected work display', async () => {
+  it('FeaturedProjects renders a scrollable two-row project showcase', async () => {
     queryMocks.getFeaturedProjects.mockResolvedValue({
       data: Array.from({ length: 5 }, (_, index) => ({
         id: `project-${index + 1}`,
@@ -89,15 +89,43 @@ describe('public islands (unit)', () => {
       })),
       error: null,
     });
+    queryMocks.getPublishedProjects.mockResolvedValue({
+      data: [],
+      error: null,
+    });
 
-    await render(<FeaturedProjects limit={3} />);
-    expect(container.textContent).toContain('Project 3');
-    expect(container.textContent).not.toContain('Project 4');
+    await render(<FeaturedProjects />);
+    expect(container.querySelector('.project-scroll-stage')).not.toBeNull();
+    expect(container.querySelectorAll('.project-scroll-row').length).toBe(2);
+    expect(container.textContent).toContain('Project 1');
+    expect(container.textContent).toContain('Project 5');
   });
 
   it('ProjectList renders an empty state when no projects exist', async () => {
     await render(<ProjectList />);
     expect(container.textContent).toContain('No published projects match these filters yet.');
+  });
+
+  it('ProjectList defaults to a mixed-size gallery view', async () => {
+    queryMocks.getPublishedProjects.mockResolvedValue({
+      data: Array.from({ length: 3 }, (_, index) => ({
+        id: `project-${index + 1}`,
+        title: `Project ${index + 1}`,
+        slug: `project-${index + 1}`,
+        project_status: 'active',
+        is_deployed: false,
+        image_url: null,
+        display_order: index + 1,
+        summary: `Project ${index + 1} summary`,
+      })),
+      error: null,
+    });
+
+    await render(<ProjectList />);
+    expect(container.querySelector('.project-showcase-grid')).not.toBeNull();
+    expect(container.querySelector('.project-showcase-card--xl')).not.toBeNull();
+    expect(container.textContent).toContain('Gallery');
+    expect(container.textContent).toContain('Cards');
   });
 
   it('NewsList renders a visitor-facing empty state when no news exists', async () => {

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -36,7 +36,7 @@ export async function getFeaturedProjects(): Promise<{
   if (!isSupabaseConfigured) return { data: [], error: null };
 
   const projectCardSelect =
-    'id, title, slug, project_status, is_deployed, is_featured, image_url, display_order, summary, deployment_status, impact_area, timeline, project_year, best_fit, core_capabilities, tech_stack, implementation_countries, capabilities_involved, sdgs';
+    'id, title, slug, project_status, is_deployed, is_featured, image_url, display_order, summary, deployment_status, impact_area, timeline, project_year, best_fit, core_capabilities, tech_stack, implementation_countries, capabilities_involved, sdgs, video_url';
 
   const { data, error } = await getSupabase()
     .from('projects')

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -142,7 +142,7 @@ export interface PageContent {
 }
 
 export type StatisticCard = Pick<Statistic, "id" | "label" | "value" | "icon_name" | "display_order">;
-export type FeaturedProjectCard = Pick<Project, "id" | "title" | "slug" | "project_status" | "is_deployed" | "image_url" | "display_order" | "summary" | "deployment_status" | "sdgs" | "is_sample" | "is_featured" | "impact_area" | "timeline" | "project_year" | "best_fit" | "core_capabilities" | "tech_stack" | "implementation_countries" | "capabilities_involved">;
+export type FeaturedProjectCard = Pick<Project, "id" | "title" | "slug" | "project_status" | "is_deployed" | "image_url" | "display_order" | "summary" | "deployment_status" | "sdgs" | "is_sample" | "is_featured" | "impact_area" | "timeline" | "project_year" | "best_fit" | "core_capabilities" | "tech_stack" | "implementation_countries" | "capabilities_involved" | "video_url">;
 export type ProjectListItem = FeaturedProjectCard;
 export type NewsListItem = Pick<NewsArticle, "id" | "title" | "slug" | "summary" | "featured_image_url" | "author_name" | "publish_date">;
 export type PersonCard = Pick<Person, "id" | "name" | "role_title" | "photo_url" | "biography" | "display_order">;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -337,36 +337,35 @@ const heroSlides = [
     </section>
 
     <section
-      class="bg-lab-surface py-[clamp(70px,8vw,112px)]"
+      class="overflow-hidden bg-lab-base py-[clamp(80px,9vw,128px)]"
       aria-labelledby="portfolio-heading"
     >
-      <div class="mx-auto w-[min(100%-2rem,1120px)]">
-        <div class="mb-10 max-w-[760px]">
-          <!-- <span
-            class="mb-3.5 inline-flex rounded-full bg-lab-surface px-3 py-1.5 text-xs font-black uppercase tracking-[0.12em] text-lab-accent-soft"
-          >
-            Portfolio
-          </span> -->
-          <h2
-            id="portfolio-heading"
-            class="m-0 text-[clamp(2rem,3.2vw,3.05rem)] font-black leading-[1.08] tracking-[-0.04em] text-lab-text"
-          >
-            Explore our project portfolio
-          </h2>
-          <p class="mt-3.5 text-base font-semibold leading-7 text-lab-muted">
-            Browse real-world AI projects, practical approaches, and reusable
-            solutions developed with UNDP teams and partners.
-          </p>
-        </div>
-        <FeaturedProjects client:load limit={3} />
-        <div class="mt-[46px] flex justify-center">
-          <a
-            href={withBase('/projects')}
-            class="inline-flex min-h-11 items-center justify-center gap-2 rounded-full bg-lab-accent px-5 py-3 text-sm font-extrabold text-lab-text no-underline shadow-[0_14px_30px_rgba(76,141,255,0.24)] transition hover:-translate-y-0.5 hover:bg-primary-dark focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-4 focus-visible:outline-lab-accent/40"
-          >
-            View all projects <span aria-hidden="true">&rarr;</span>
-          </a>
-        </div>
+      <div class="mx-auto mb-10 w-[min(100%-2rem,1120px)] max-w-[760px]">
+        <h2
+          id="portfolio-heading"
+          class="m-0 text-[clamp(2.2rem,3.8vw,3.6rem)] font-black leading-[1.02] tracking-[-0.045em] text-lab-text"
+        >
+          Explore our project portfolio
+        </h2>
+        <p class="mt-3.5 text-base font-semibold leading-7 text-lab-muted">
+          Browse real-world AI projects, practical approaches, and reusable
+          solutions developed with UNDP teams and partners.
+        </p>
+      </div>
+      <FeaturedProjects client:load />
+      <div
+        class="mx-auto mt-[46px] flex w-[min(100%-2rem,1120px)] flex-col justify-between gap-6 sm:flex-row sm:items-end"
+      >
+        <a
+          href={withBase('/projects')}
+          class="inline-flex min-h-11 items-center justify-center gap-2 rounded-full bg-lab-accent px-5 py-3 text-sm font-extrabold text-lab-text no-underline shadow-[0_14px_30px_rgba(76,141,255,0.24)] transition hover:-translate-y-0.5 hover:bg-primary-dark focus-visible:outline focus-visible:outline-4 focus-visible:outline-offset-4 focus-visible:outline-lab-accent/40"
+        >
+          View all projects <span aria-hidden="true">&rarr;</span>
+        </a>
+        <p class="max-w-md text-sm font-semibold leading-6 text-lab-muted sm:text-right">
+          Practical AI and data solutions built with UNDP teams, governments
+          and partners.
+        </p>
       </div>
     </section>
 

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -39,9 +39,7 @@ import ProjectList from '../../islands/ProjectList';
       class="bg-lab-surface pb-[clamp(72px,8vw,112px)] pt-3"
       aria-label="Browse projects"
     >
-      <div class="mx-auto w-[min(100%-2rem,1120px)]">
-        <ProjectList client:load />
-      </div>
+      <ProjectList client:load />
     </section>
   </main>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -311,7 +311,9 @@
       opacity 520ms ease,
       transform 520ms ease,
       visibility 0ms linear 0ms;
-  }.hero-control-button {
+  }
+
+  .hero-control-button {
     display: inline-flex;
     min-height: 2rem;
     align-items: center;
@@ -366,6 +368,136 @@
   }
 }
 
+
+.project-showcase-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+  padding: 0 1rem;
+}
+
+.project-showcase-card {
+  position: relative;
+  display: block;
+  min-height: 17rem;
+  overflow: hidden;
+  border-radius: 1.15rem;
+  background: var(--lab-surface);
+  text-decoration: none;
+}
+
+.project-showcase-card__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: end;
+  padding: 1.15rem 1.25rem 1.25rem;
+  background: linear-gradient(180deg, rgba(34, 36, 42, 0.02) 32%, rgba(34, 36, 42, 0.86) 100%);
+}
+
+@media (min-width: 768px) {
+  .project-showcase-grid {
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    grid-auto-rows: minmax(11.5rem, 18vw);
+    gap: 0.55rem;
+    padding: 0 max(1rem, calc((100vw - 1200px) / 2));
+  }
+
+  .project-showcase-card {
+    min-height: 0;
+  }
+
+  .project-showcase-card--xl {
+    grid-column: span 8;
+    grid-row: span 2;
+  }
+
+  .project-showcase-card--tall {
+    grid-column: span 4;
+    grid-row: span 2;
+  }
+
+  .project-showcase-card--compact {
+    grid-column: span 4;
+    grid-row: span 2;
+  }
+
+  .project-showcase-card--wide {
+    grid-column: span 8;
+    grid-row: span 2;
+  }
+
+  .project-showcase-card--mid {
+    grid-column: span 6;
+    grid-row: span 2;
+  }
+}
+
+.project-scroll-stage {
+  overflow: hidden;
+  padding: 0.35rem 0 0.75rem;
+}
+
+.project-scroll-row {
+  display: flex;
+  width: max-content;
+  gap: 0.9rem;
+  will-change: transform;
+}
+
+.project-scroll-row + .project-scroll-row {
+  margin-top: 0.9rem;
+}
+
+.project-scroll-row--bottom {
+  margin-left: 4.5rem;
+}
+
+.project-scroll-card,
+.project-scroll-stage .project-showcase-card {
+  flex: 0 0 auto;
+  width: min(20.5rem, 78vw);
+  height: 13.75rem;
+  min-height: 13.75rem;
+  border-radius: 1.15rem;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.22);
+}
+
+.project-scroll-card--wide,
+.project-scroll-stage .project-scroll-card--wide {
+  width: min(24.5rem, 84vw);
+}
+
+.project-scroll-card--skeleton {
+  border-radius: 1.15rem;
+  background: var(--lab-section);
+}
+
+@media (min-width: 768px) {
+  .project-scroll-row--bottom {
+    margin-left: 7rem;
+  }
+
+  .project-scroll-card,
+  .project-scroll-stage .project-showcase-card {
+    width: 23rem;
+    height: 15.5rem;
+    min-height: 15.5rem;
+  }
+
+  .project-scroll-card--wide,
+  .project-scroll-stage .project-scroll-card--wide {
+    width: 27.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .project-scroll-row {
+    will-change: auto;
+    transform: none !important;
+  }
+}
 
 @keyframes hero-project-scroll {
   0% {

--- a/tests/integration/astro-components.integration.test.ts
+++ b/tests/integration/astro-components.integration.test.ts
@@ -61,7 +61,7 @@ describe('Homepage v3 composition integration', () => {
 
   it('composes the current light homepage hero and portfolio sections', () => {
     expect(indexPage).toContain('We help UNDP teams turn complex challenges into AI solutions.');
-    expect(indexPage).toContain('<FeaturedProjects client:load limit={3} />');
+    expect(indexPage).toContain('<FeaturedProjects client:load />');
     expect(indexPage).toContain('<PartnerLogos client:load variant="marquee" />');
     expect(indexPage).toContain('Explore our project portfolio');
   });


### PR DESCRIPTION
Add a mixed-size gallery on /projects and a two-row scroll-linked showcase on the homepage, so the portfolio reads as strongly as the hero without duplicating search.